### PR TITLE
fix typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# electron-i18n 
+# electron-i18n
 
 A home for Electron's translated documentation.
 
@@ -32,7 +32,7 @@ content
         └── locale.yml
 ```
 
-To get a sense of how content is organized, see [crowdin.yaml](crowdin.yaml)
+To get a sense of how content is organized, see [crowdin.yml](crowdin.yml)
 
 ## License
 


### PR DESCRIPTION
##### Summary
`crowdin.yaml` => `crowdin.yml`

##### Preview
https://github.com/watilde/electron-i18n/blob/b3ee2d6594efe43cea964d7a995e440c4d1b7ce7/readme.md#content