### PR TITLE
test congruency of API descriptions

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -44,9 +44,9 @@ describe('electron-i18n', () => {
       expect(sourceKeys).to.include('app.events.continue-activity.returns.type.description')
 
       expect(locales.length).to.be.above(10)
-      // locales.forEach(locale => {
-      //   expect(sourceKeys).to.deep.equal(getKeys(locale), `${locale} API descriptions tree does not match source content`)
-      // })
+      locales.forEach(locale => {
+        expect(sourceKeys).to.deep.equal(getKeys(locale), `${locale} API descriptions tree does not match source content`)
+      })
     })
   })
 })


### PR DESCRIPTION
Now that Crowdin is using the new flat key-value YML structure, all is well and the keys line up.

🔑 🔑 🔑 🔑 🔑 🔑 