### PR TITLE
Get API by slug

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,36 +3,12 @@ const fs = require('fs')
 const assert = require('assert')
 const objectifyArray = require('objectify-array')
 const flat = require('flat')
-const {set} = require('lodash')
-const requireYAML = require('require-yml')
-
 const contentDir = path.join(__dirname, './content')
-const apis = require(path.join(contentDir, 'en/api/electron-api.json'))
-  .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+const apis = require('./lib/apis')
 const tree = objectifyArray(apis)
-const locales = fs.readdirSync(contentDir)
-  .filter(filename => fs.statSync(path.join(contentDir, filename)).isDirectory())
-
-
-
-function preTranslateApiDocs () {
-  const trees = {}  
-  locales.forEach(locale => {
-    let descriptionsPath = path.join(contentDir, `${locale}/api/api-descriptions.yml`)
-    let descriptions = requireYAML(descriptionsPath)
-    // console.log(locale, descriptions['app.description'])
-    let result = Object.assign({}, tree)
-    Object.keys(descriptions).forEach(key => {
-      set(result, key, descriptions[key])
-    })
-    
-    // serialize before storing. not sure why it doesn't work otherwise
-    trees[locale] = JSON.stringify(result)
-  })  
-  return trees
-}
-
-const translatedTrees = preTranslateApiDocs()
+const locales = require('./lib/locales')
+const slugs = require('./lib/get-slugs')(apis)
+const translatedTrees = require('./lib/pretranslate')()
 
 module.exports = {
   api: {
@@ -43,9 +19,11 @@ module.exports = {
   locales: locales
 }
 
-function getApi (api, locale = 'en') {
-  assert(Object.keys(tree).includes(api), `Unsupported API: ${api}`)
+function getApi (apiName, locale = 'en') {
   assert(locales.includes(locale), `Unsupported locale: ${locale}`)
-  return JSON.parse(translatedTrees[locale])[api]
+  const tree = JSON.parse(translatedTrees[locale])
+  const api = tree[apiName] || tree[slugs[apiName]]
+  assert(api, `Unsupported API: ${api}`)
+  return api
 }
 

--- a/lib/apis.js
+++ b/lib/apis.js
@@ -1,0 +1,5 @@
+const path = require('path')
+const contentDir = path.join(__dirname, '../content')
+
+module.exports = require(path.join(contentDir, 'en/api/electron-api.json'))
+  .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))

--- a/lib/get-slugs.js
+++ b/lib/get-slugs.js
@@ -1,0 +1,8 @@
+// Map URL-friendly API names to their real names.
+module.exports = function getSlugs (apis) {
+  const slugs = {}
+  apis.forEach(api => {
+    slugs[api.slug] = api.name
+  })
+  return slugs
+}

--- a/lib/locales.js
+++ b/lib/locales.js
@@ -1,0 +1,6 @@
+const path = require('path')
+const fs = require('fs')
+const contentDir = path.join(__dirname, '../content')
+
+module.exports = fs.readdirSync(contentDir)
+  .filter(filename => fs.statSync(path.join(contentDir, filename)).isDirectory())

--- a/lib/pretranslate.js
+++ b/lib/pretranslate.js
@@ -1,0 +1,26 @@
+const path = require('path')
+const fs = require('fs')
+const requireYAML = require('require-yml')
+const objectifyArray = require('objectify-array')
+const {set} = require('lodash')
+const contentDir = path.join(__dirname, '../content')
+const locales = require('../lib/locales')
+const apis = require('../lib/apis')
+const tree = objectifyArray(apis)
+
+// Do this work up front, so it only needs to happen once at load time.
+module.exports = function preTranslateApiDocs () {
+  const trees = {}  
+  locales.forEach(locale => {
+    let descriptionsPath = path.join(contentDir, `${locale}/api/api-descriptions.yml`)
+    let descriptions = requireYAML(descriptionsPath)
+    let result = Object.assign({}, tree)
+    Object.keys(descriptions).forEach(key => {
+      set(result, key, descriptions[key])
+    })
+    
+    // serialize before storing. not sure why it doesn't work otherwise
+    trees[locale] = JSON.stringify(result)
+  })  
+  return trees
+}

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ Exports an array of locale names that are currently being translated.
 Returns an structured object for the given API, with translations applied from 
 the given locale.
 
-- `api` String - an Electron API like `app` or `BrowserWindow` (required)
+- `api` String - an Electron API like `app` or `BrowserWindow`. Can be the full name like `BrowserWindow`, or the URL-friendly slug like `browser-window`. (required)
 - `locale` String - a language locale (optional; defaults to `en`)
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -31,17 +31,27 @@ describe('electron-i18n', () => {
       expect(i18n.locales).to.include('fr-FR')
     })
 
-    it('exports a method for getting translated structured API docs by locale', () => {
-      let app = i18n.api.get('app')
-      expect(app.description).to.include('Control your application')
+    describe('api.get', () => {
+      it('is a method for getting translated structured API docs by locale', () => {
+        let app = i18n.api.get('app')
+        expect(app.description).to.include('Control your application')
 
-      app = i18n.api.get('app', 'fr-FR')
-      expect(app.description).to.include('Contrôle le cycle de vie')
-      expect(app.methods.quit.description).to.include('Essaye de fermer toutes les fenêtres')
+        app = i18n.api.get('app', 'fr-FR')
+        expect(app.description).to.include('Contrôle le cycle de vie')
+        expect(app.methods.quit.description).to.include('Essaye de fermer toutes les fenêtres')
 
-      app = i18n.api.get('app', 'vi-VN')
-      expect(app.description).to.include('Kiểm soát các vòng')
-      expect(app.methods.relaunch.description).to.include('ứng dụng khi thoát khỏi')
+        app = i18n.api.get('app', 'vi-VN')
+        expect(app.description).to.include('Kiểm soát các vòng')
+        expect(app.methods.relaunch.description).to.include('ứng dụng khi thoát khỏi')
+      })
+
+      it('allows lookup by API name or url-friendly slug', () => {
+        const api1 = i18n.api.get('BrowserWindow')
+        expect(api1).to.be.an('object')
+        const api2 = i18n.api.get('browser-window')
+        expect(api2).to.be.an('object')
+        expect(api1).to.deep.equal(api2)
+      })
     })
   })
 


### PR DESCRIPTION
This PR adds support for fetching translated API object using the `name` or the `slug` of the API.

```js
i18n.api.get('BrowserWindow')
// or 
i18n.api.get('browser-window')
```