### PR TITLE
disable prepack check

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "build": "script/build.js",
     "test": "mocha",
     "release": "script/release.sh",
-    "prepack": "check-for-leaks",
     "prepush": "check-for-leaks"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "electron-i18n",
+  "private": true,
   "version": "1.0.0",
   "description": "The home of Electron's translateable content",
   "main": "index.js",


### PR DESCRIPTION
For some reason npm freaks out about github:foo/bar modules that have script hooks.

We are not currently publishing this module to npm, so it's safe to remove this check for now. Also set `private` to `true` in the package.json to prevent publishes.

```
-----> Building dependencies
       Installing node modules (package.json + package-lock)
       
       > electron-i18n@1.0.0 prepack /app/.npm/_cacache/tmp/git-clone-aebac26d
       > check-for-leaks
       
       sh: 1: check-for-leaks: not found
       npm ERR! file sh
       npm ERR! code ELIFECYCLE
       npm ERR! errno ENOENT
       npm ERR! syscall spawn
       npm ERR! electron-i18n@1.0.0 prepack: `check-for-leaks`
       npm ERR! spawn ENOENT
       npm ERR!
       npm ERR! Failed at the electron-i18n@1.0.0 prepack script.
       npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
       
       npm ERR! A complete log of this run can be found in:
       npm ERR!     /app/.npm/_logs/2017-08-15T08_21_24_524Z-debug.log
```