### PR TITLE
add license, CoC, and contributing doc

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at electron@github.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,101 @@
+# Contributing to electron-i18n
+
+🇨🇳 🇹🇼 🇧🇷 🇪🇸 🇰🇷 🇯🇵 🇷🇺 🇫🇷 🇹🇭 🇳🇱 🇹🇷 🇮🇩 🇺🇦 🇨🇿 🇮🇹
+
+💚 First off, thanks for taking the time to contribute! 💚
+
+Anyone is welcome to join in the effort, regardless of technical experience or 
+familiarity with the Electron project.
+
+This project adheres to the Contributor Covenant [code of conduct](code_of_conduct.md).
+By participating, you are expected to uphold this code. Please report unacceptable
+behavior to electron@github.com.
+
+The following is a set of guidelines for contributing to Electron's localization
+effort. These are just guidelines, not rules, so use your best judgment and 
+feel free to propose changes to this document in a pull request.
+
+## Translating
+
+👉 **Do not translate the content directly in this repository!**
+
+Electron's localization effort uses [Crowdin], an awesome platform for 
+collaborative translation. Changes on Crowdin are  automatically turned into 
+pull requests on this GitHub repository.
+
+To get started, visit 
+**[crowdin.com/project/electron](https://crowdin.com/project/electron)** 
+and log in with your GitHub account.
+
+## Developing `electron-i18n`
+
+The rest of this document describes how this repo is structured, how
+it syncs with Crowdin, and how to make technical changes.
+
+**If you're just here to translate, you probably don't need to read this.**
+
+### Environment Setup
+
+To fetch the latest docs, you need a GitHub token. Visit
+github.com/settings/tokens/new](https://github.com/settings/tokens/new)
+to create one. No special scopes needed.
+
+```sh
+cp .env.example .env
+```
+
+Then edit `.env` and add your token. 
+
+```sh
+npm run build
+```
+
+### Source Content
+
+Electron's documentation and website are authored in English.
+
+The source content in this repo is collected from a few places:
+
+- Markdown files from the [electron](https://github.com/electron/electron/tree/master/docs) repo.
+- YAML files from the [electron.atom.io](https://github.com/electron/electron.atom.io/tree/gh-pages/_data/) repo
+- Electron's [structured API docs](https://electron.atom.io/blog/2016/09/27/api-docs-json-schema).
+
+Here's the directory structure:
+
+```
+content
+└── en
+    ├── api
+    ├── docs
+    └── website
+```
+
+### Translated Content
+
+[The Crowdin project](https://crowdin.com/project/electron) is configured to automatically **pull** the latest English content out of this repo and **push** the translated content back into this repo.
+
+Translations are added under a directory named after the locale. The _contents_ of these files differ by language, but the _directory structure and filenames_ for each locale is always identical.
+
+```
+content
+├── en
+│   ├── api
+│   ├── docs
+│   └── website
+├── es
+│   ├── api
+│   ├── docs
+│   └── website
+├── pt-BR
+│   ├── api
+│   ├── docs
+│   └── website
+└── zh-TW
+    ├── api
+    ├── docs
+    └── website
+```
+
+To get a sense of how content is transformed, see [crowdin.yml](crowdin.yml)
+
+[Crowdin]: https://crowdin.com/project/electron

--- a/crowdin.md
+++ b/crowdin.md
@@ -1,0 +1,28 @@
+## Crowdin
+
+Electron's localization effort uses [Crowdin], an awesome platform for 
+collaborative translation. It's free for open source projects, and anyone
+who understands multiples languages is welcome to join in the effort, regardless 
+of their technical experience or familiarity with the Electron project.
+
+## Why Crowdin?
+
+GitHub's documentation team reviewed numerous localization platforms (XTM, Smartling, Memsource, LingoHub, Qordoba, Transifex) before choosing [Crowdin](http://crowdin.com). We found Crowdin to be the best fit for the needs of the Electron project, as it satisfies most of our unique requirements.
+
+## Our Requirements
+
+- **GitHub Flavored Markdown.** Some other localization platforms do not support markdown, on the basis that it is "unstructured" (though Githubbers are [working on that](https://githubengineering.com/a-formal-spec-for-github-markdown/). Other platforms have markdown support, but few have full support for GFM.
+- **Aribtrary YAML data.** Many localization platforms support YAML, but some have specific requirements about its structure, such as a locale key like `en` at the root node of the file.
+- **YAML frontmatter.** Tools like Jekyll (upon which the Electron website is built) use a block of key-value metadata atop markdown files like `date`, `keywords`, `author`, `permalink`, etc. This content needs to be translated while preserving the original YAML structure.
+
+## Features
+
+In addition to satifying our project's unique requirements, Crowdin has some compelling features:
+
+- **GitHub Integration.** Crowdin is the only provider we evaluated that can integrate with GitHub and automatically sync content in and out of repositories.
+- **Machine Translations.** Crowdin supports machine translation using APIs from Microsoft and Google. This may allow us to save human time and energy by automating the initial translation of doc sets.
+- **Crowdsourcing.** Electron has a huge community of open-source
+contributors. Whether or not we end up paying professionals to help translate Electron's docs, we will always want the localization process to be as transparent and inclusive as possible. Other localization platforms are geared toward professional translators, whereas Crowdin can be used by anyone, and has some unique collaborative features like voting.
+- **Login with GitHub** Translators can log in with their GitHub accounts. This makes the onboarding process easier for participants, and gives  us an easier way to know who to thank for the contributions.
+
+[Crowdin]: https://crowdin.com/project/electron

--- a/license
+++ b/license
@@ -1,0 +1,28 @@
+electron-i18n - A home for Electron's translated documentation.
+
+Copyright (c) 2017, GitHub
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. The name Gregor Aisch may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL GREGOR AISCH OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/readme.md
+++ b/readme.md
@@ -8,79 +8,13 @@
 
 Do you speak multiple languages? We need your help! 
 
-Visit **[crowdin.com/project/electron](https://crowdin.com/project/electron)** and log in with your GitHub account to help translate.
-
-
-## Source Content
-
-Electron's documentation and website are authored in English.
-
-The source content in this repo is collected from a few places:
-
-- Markdown files from the [electron](https://github.com/electron/electron/tree/master/docs) repo.
-- YAML files from the [electron.atom.io](https://github.com/electron/electron.atom.io/tree/gh-pages/_data/) repo
-- Electron's [structured API docs](https://electron.atom.io/blog/2016/09/27/api-docs-json-schema).
-
-Here's the directory structure:
-
-```
-content
-└── en
-    ├── api
-    ├── docs
-    └── website
-```
-
-## Translated Content
-
-[The Crowdin project](https://crowdin.com/project/electron) is configured to automatically **pull** the latest English content out of this repo and **push** the translated content back into this repo.
-
-Translations are added under a directory named after the locale. The _contents_ of these files differ by language, but the _directory structure and filenames_ for each locale is always identical.
-
-```
-content
-├── en
-│   ├── api
-│   ├── docs
-│   └── website
-├── es
-│   ├── api
-│   ├── docs
-│   └── website
-├── pt-BR
-│   ├── api
-│   ├── docs
-│   └── website
-└── zh-TW
-    ├── api
-    ├── docs
-    └── website
-```
-
-To get a sense of how content is transformed, see [crowdin.yml](crowdin.yml)
-
-## Why Crowdin?
-
-GitHub's documentation team reviewed numerous localization platforms (XTM, Smartling, Memsource, LingoHub, Qordoba, Transifex) before choosing [Crowdin](http://crowdin.com). We found Crowdin to be the best fit for the needs of the Electron project, as it satisfies most of our unique requirements:
-
-- **GitHub Flavored Markdown.** Some other localization platforms do not support markdown, on the basis that it is "unstructured" (though Githubbers are [working on that](https://githubengineering.com/a-formal-spec-for-github-markdown/). Other platforms have markdown support, but few have full support for GFM.
-- **Aribtrary YAML data.** Many localization platforms support YAML, but some have specific requirements about its structure, such as a locale key like `en` at the root node of the file.
-- **YAML frontmatter.** Tools like Jekyll (upon which the Electron website is built) use a block of key-value metadata atop markdown files like `date`, `keywords`, `author`, `permalink`, etc. This content needs to be translated while preserving the original YAML structure.
-
-In addition to satifying our project's unique requirements, Crowdin has some compelling features:
-
-- **GitHub Integration.** Crowdin is the only provider we evaluated that can integrate with GitHub and automatically sync content in and out of repositories.
-- **Machine Translations.** Crowdin supports machine translation using APIs from Microsoft and Google. This may allow us to save human time and energy by automating the initial translation of doc sets.
-- **Crowdsourcing.** Electron has a huge community of open-source
-contributors. Whether or not we end up paying professionals to help translate Electron's docs, we will always want the localization process to be as transparent and inclusive as possible. Other localization platforms are geared toward professional translators, whereas Crowdin can be used by anyone, and has some unique collaborative features like voting.
-- **Login with GitHub** Translators can log in with their GitHub accounts. This makes the onboarding process easier for participants, and gives  us an easier way to know who to thank for the contributions.
+See [contributing.md](contributing.md) for info on how to participate.
 
 ## Installation and Usage
 
-If you are here to help translate, visit 
-**[crowdin.com/project/electron](https://crowdin.com/project/electron)** and log in with your GitHub account to get started.
+If you're just here to translate content, see [contributing.md](contributing.md)
 
-If you are here to use this translated content for some purpose, read on!
+If you're here to _use_ this translated content for some purpose, read on!
 
 This repo is also a node module for working with Electron's translated content.
 
@@ -123,7 +57,8 @@ the given locale.
 - `api` String - an Electron API like `app` or `BrowserWindow`. Can be the full name like `BrowserWindow`, or the URL-friendly slug like `browser-window`. (required)
 - `locale` String - a language locale (optional; defaults to `en`)
 
-
 ## License
 
-MIT
+[MIT](license)
+
+[Crowdin]: https://crowdin.com/project/electron


### PR DESCRIPTION
This PR: 

- lightens up the README
- moves Crowdin info to its own doc
- adds a [Contributor Covenant](contributor-covenant.org) Code of Conduct
- adds an MIT license file
- documents the build process

📝 ⚖️ 💡 

cc @alebourne @bernars