### PR TITLE
ensure doc always has title

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -62,7 +62,7 @@ async function parseFile (file) {
 
   // derive props from the HTML
   const $ = cheerio.load(file.html || '')
-  file.title = $('h1').text()
+  file.title = $('h1').text() !== '' ? $('h1').text() : $('h2').text() 
   file.description = $('blockquote').text()
 
   // remove leftover file props from walk-sync

--- a/script/build.js
+++ b/script/build.js
@@ -62,7 +62,7 @@ async function parseFile (file) {
 
   // derive props from the HTML
   const $ = cheerio.load(file.html || '')
-  file.title = $('h1').text() !== '' ? $('h1').text() : $('h2').text() 
+  file.title = $('h1').text() || $('h2').text()
   file.description = $('blockquote').text()
 
   // remove leftover file props from walk-sync

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,17 @@ describe('i18n.website', () => {
 })
 
 describe('API Docs', () => {
+  it('has a title for every doc', () => {
+    const locales = Object.keys(i18n.locales)
+    locales.forEach(locale => {
+      const docs = Object.keys(i18n.docs[locale]).map(key => i18n.docs[locale][key])
+      const titles = docs.map(doc => doc.title)
+      const hasTitle = (title) => title !== ''
+
+      titles.every(hasTitle).should.equal(true)
+    })
+  })
+
   it('includes all expected properties', () => {
     const app = i18n.docs['en-US']['/docs/api/app']
     app.isApiDoc.should.equal(true)


### PR DESCRIPTION
Ensure that docs always have titles by plucking `h2` text if `h1` is empty.

Change:
`file.title = $('h1').text() !== '' ? $('h1').text() : $('h2').text() `

/cc @zeke 