### PR TITLE
fix: make titles test more robust

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -62,7 +62,7 @@ async function parseFile (file) {
 
   // derive props from the HTML
   const $ = cheerio.load(file.html || '')
-  file.title = $('h1').text() || $('h2').text()
+  file.title = $('h1').text() || $('h2').text().replace('Class: ', '')
   file.description = $('blockquote').text()
 
   // remove leftover file props from walk-sync

--- a/test/index.js
+++ b/test/index.js
@@ -41,11 +41,12 @@ describe('i18n.website', () => {
 describe('API Docs', () => {
   it('has a title for every doc', () => {
     const locales = Object.keys(i18n.locales)
+    locales.length.should.be.above(1)
     locales.forEach(locale => {
       const docs = Object.keys(i18n.docs[locale]).map(key => i18n.docs[locale][key])
       const titles = docs.map(doc => doc.title)
       const hasTitle = (title) => title !== ''
-
+      titles.length.should.be.above(1)
       titles.every(hasTitle).should.equal(true)
     })
   })


### PR DESCRIPTION
This updates the title tests to make sure we're not checking empty collections. This is a subtle gotcha of using `some` and `every` in tests.

Note how this returns true even though it's kind of a logical fallacy or something:

```
$ node          
> [].every(thing => thing === 'hello')
true
```