### PR TITLE
fix relative links in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "electron-docs": "^3.0.2",
     "github": "^9.2.0",
     "got": "^6.7.1",
+    "href-type": "^1.0.1",
     "hubdown": "^1.0.0",
     "husky": "^0.14.3",
     "js-yaml": "^3.8.4",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 require('chai').should()
 const {describe, it} = require('mocha')
 const i18n = require('..')
+const cheerio = require('cheerio')
 
 describe('i18n.docs', () => {
   it('is an object with locales as keys', () => {
@@ -93,6 +94,13 @@ describe('API Docs', () => {
 
       sortedSlugs.should.deep.equal(slugs)
     })
+  })
+
+  it('fixes relative links in docs', () => {
+    const api = i18n.docs['en-US']['/docs/api/app']
+    const $ = cheerio.load(api.html)
+    const link = $('a[href*="glossary"]').first()
+    link.attr('href').should.equal('/docs/glossary#main-process')
   })
 })
 


### PR DESCRIPTION
Markdown docs are written for consumption in GitHub, so they have HREFS like `../glossary.md#main-process`. This PR updates all relative links in the docs to match the URL of that content on the website, e.g. `/docs/glossary#main-process`