### PR TITLE
fix: use new major version of semantic-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,109 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@semantic-release/commit-analyzer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-2.0.0.tgz",
-      "integrity": "sha1-kk0eLDAWfGpHK+2fZu6Pjgd0ibI=",
-      "dev": true,
-      "requires": {
-        "conventional-changelog": "0.0.17"
-      }
-    },
-    "@semantic-release/condition-travis": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/condition-travis/-/condition-travis-5.0.2.tgz",
-      "integrity": "sha1-9Lt3emxttVZdcHVKm2KSM71KZZc=",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "1.0.0",
-        "semver": "5.4.1",
-        "travis-deploy-once": "1.0.0-node-0.10-support"
-      }
-    },
-    "@semantic-release/error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-1.0.0.tgz",
-      "integrity": "sha1-u4+O7t1cf4xG+Ws37znhuMN2wcw=",
-      "dev": true
-    },
-    "@semantic-release/last-release-npm": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/last-release-npm/-/last-release-npm-1.2.1.tgz",
-      "integrity": "sha1-/3SBQuzxU1S4M6hroYIF9/zllO4=",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "1.0.0",
-        "npm-registry-client": "7.5.0",
-        "npmlog": "1.2.1"
-      },
-      "dependencies": {
-        "are-we-there-yet": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-          "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
-          "dev": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "dev": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
-          }
-        },
-        "npmlog": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-          "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-          "dev": true,
-          "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.0.6",
-            "gauge": "1.2.7"
-          }
-        }
-      }
-    },
-    "@semantic-release/release-notes-generator": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-3.0.1.tgz",
-      "integrity": "sha512-7KpT3eKOWf6Sd+3vWJgbBEdMKbqgsLiDNq+U0EwEadKdbTxaxDtSWYixw0S8Kd+0jv5CvmMpHxac5jTV3f54Xg==",
-      "dev": true,
-      "requires": {
-        "conventional-changelog": "1.1.4",
-        "github-url-from-git": "1.5.0"
-      },
-      "dependencies": {
-        "conventional-changelog": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.4.tgz",
-          "integrity": "sha1-EIvHUMKjF+IA4vm0E8qqH4x++js=",
-          "dev": true,
-          "requires": {
-            "conventional-changelog-angular": "1.5.0",
-            "conventional-changelog-atom": "0.1.1",
-            "conventional-changelog-codemirror": "0.1.0",
-            "conventional-changelog-core": "1.9.1",
-            "conventional-changelog-ember": "0.2.7",
-            "conventional-changelog-eslint": "0.1.0",
-            "conventional-changelog-express": "0.1.0",
-            "conventional-changelog-jquery": "0.1.0",
-            "conventional-changelog-jscs": "0.1.0",
-            "conventional-changelog-jshint": "0.1.0"
-          }
-        }
-      }
-    },
     "@types/node": {
       "version": "6.0.88",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
@@ -191,12 +88,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
       "dev": true
     },
     "ansi-escapes": {
@@ -322,12 +213,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -443,12 +328,6 @@
       "requires": {
         "readable-stream": "2.3.3"
       }
-    },
-    "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-      "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -730,6 +609,21 @@
       "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
       "dev": true
     },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -806,44 +700,6 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
-    "conventional-changelog": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.17.tgz",
-      "integrity": "sha1-XgIWYA9GhhkPDILvuws90RtJzjQ=",
-      "dev": true,
-      "requires": {
-        "dateformat": "1.0.12",
-        "event-stream": "3.3.4",
-        "github-url-from-git": "1.5.0",
-        "lodash": "3.10.1",
-        "normalize-package-data": "1.0.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
-          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
-          "dev": true,
-          "requires": {
-            "github-url-from-git": "1.5.0",
-            "github-url-from-username-repo": "1.0.2",
-            "semver": "4.3.6"
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        }
-      }
-    },
     "conventional-changelog-angular": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.0.tgz",
@@ -851,24 +707,6 @@
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
-        "q": "1.5.0"
-      }
-    },
-    "conventional-changelog-atom": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.1.tgz",
-      "integrity": "sha512-6Nlu/+MiD4gi7k3Z+N1vMJWpaPSdvFPWzPGnH4OXewHAxiAl0L/TT9CGgA01fosPxmYr4hMNtD7kyN0tkg8vIA==",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
-    },
-    "conventional-changelog-codemirror": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-      "integrity": "sha1-dXelkdv5tTjnoVCn7mL2WihyszQ=",
-      "dev": true,
-      "requires": {
         "q": "1.5.0"
       }
     },
@@ -891,61 +729,6 @@
         "read-pkg": "1.1.0",
         "read-pkg-up": "1.0.1",
         "through2": "2.0.3"
-      }
-    },
-    "conventional-changelog-ember": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.7.tgz",
-      "integrity": "sha512-Xj1v9uVcKM8N798hMr7e6yiw8IFyvI6Ik+TdjdmG54uGupqvEEWW37xAbPPbdKvgoitbyZkqUTancj055actEg==",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
-    },
-    "conventional-changelog-eslint": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-      "integrity": "sha1-pSQR6ZngUBzlALhWsKZD0DMJB+I=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
-    },
-    "conventional-changelog-express": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-      "integrity": "sha1-VcbIQcgRliA2wDe9vZZKVK4xD84=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
-    },
-    "conventional-changelog-jquery": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-      "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
-    },
-    "conventional-changelog-jscs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-      "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
-    },
-    "conventional-changelog-jshint": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz",
-      "integrity": "sha1-AMq46aMxdIer2UxNhGcTQpGNKgc=",
-      "dev": true,
-      "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.0"
       }
     },
     "conventional-changelog-writer": {
@@ -1021,6 +804,17 @@
       "dev": true,
       "requires": {
         "capture-stack-trace": "1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
@@ -1227,16 +1021,6 @@
         "repeat-string": "1.6.1"
       }
     },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true,
-      "requires": {
-        "asap": "2.0.6",
-        "wrappy": "1.0.2"
-      }
-    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
@@ -1319,12 +1103,6 @@
       "requires": {
         "dotenv": "4.0.0"
       }
-    },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1483,6 +1261,21 @@
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.1.1"
       }
     },
     "es6-set": {
@@ -1759,19 +1552,19 @@
         "es5-ext": "0.10.30"
       }
     },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+    "execa": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "exit-hook": {
@@ -1972,11 +1765,16 @@
         "mime-types": "2.1.17"
       }
     },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
+    "fs-extra": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2145,18 +1943,6 @@
       "requires": {
         "emoji-regex": "6.1.1"
       }
-    },
-    "github-url-from-git": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
-    },
-    "github-url-from-username-repo": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
-      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
-      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -2523,6 +2309,23 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
       "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
+    },
+    "import-from": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2892,6 +2695,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "iso-3166-1-alpha-2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.0.tgz",
@@ -2998,6 +2807,15 @@
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -3243,24 +3061,6 @@
         "lodash.isarray": "3.0.4"
       }
     },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true
-    },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
@@ -3329,6 +3129,16 @@
         "highlight.js": "9.12.0"
       }
     },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
     "make-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
@@ -3350,12 +3160,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "markdown-escapes": {
@@ -3657,22 +3461,13 @@
         "semver": "5.4.1"
       }
     },
-    "npm-registry-client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.5.0.tgz",
-      "integrity": "sha1-D23W5dEUJM+pn85bkw/q8JtPfwQ=",
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "graceful-fs": "4.1.11",
-        "normalize-package-data": "2.4.0",
-        "npm-package-arg": "4.2.1",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "request": "2.83.0",
-        "retry": "0.10.1",
-        "semver": "5.4.1",
-        "slide": "1.1.6"
+        "path-key": "2.0.1"
       }
     },
     "npmconf": {
@@ -3859,6 +3654,12 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
@@ -3872,6 +3673,30 @@
       "dev": true,
       "requires": {
         "p-limit": "1.1.0"
+      }
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
+    },
+    "p-retry": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz",
+      "integrity": "sha1-OSczKkt9cCabU1UVEX/FR9oaaWg=",
+      "dev": true,
+      "requires": {
+        "retry": "0.10.1"
+      }
+    },
+    "p-series": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-series/-/p-series-1.0.0.tgz",
+      "integrity": "sha1-fsnntEBswyBmKYpvmGDlXpGzbgc=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "1.0.0"
       }
     },
     "pako": {
@@ -3981,6 +3806,12 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-object": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/path-object/-/path-object-2.3.0.tgz",
@@ -4014,15 +3845,6 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
-      }
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
       }
     },
     "peek-stream": {
@@ -4158,6 +3980,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "pump": {
@@ -4554,27 +4382,6 @@
         "uuid": "3.1.0"
       }
     },
-    "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "require-relative": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
@@ -4671,25 +4478,10 @@
         "once": "1.4.0"
       }
     },
-    "run-auto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/run-auto/-/run-auto-2.0.0.tgz",
-      "integrity": "sha1-X0NT9Yrb1rdJJkibTyWeHa1qeNY=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "1.0.3"
-      }
-    },
     "run-parallel": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
       "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
-      "dev": true
-    },
-    "run-series": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-      "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
       "dev": true
     },
     "rx-lite": {
@@ -4705,41 +4497,269 @@
       "dev": true
     },
     "semantic-release": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-7.0.2.tgz",
-      "integrity": "sha1-PUGN9AcLH71P8re3VnYyIzDCsEk=",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-8.2.0.tgz",
+      "integrity": "sha512-b86H8268ublYLVM2ytHozVv5J4vBaRFli3q7h7wIYku7/my6mg1tWtINvapcWBfgEF2L+HKXySoLTG2B4hMc7g==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "2.0.0",
-        "@semantic-release/condition-travis": "5.0.2",
-        "@semantic-release/error": "1.0.0",
-        "@semantic-release/last-release-npm": "1.2.1",
-        "@semantic-release/release-notes-generator": "3.0.1",
+        "@semantic-release/commit-analyzer": "3.0.7",
+        "@semantic-release/condition-travis": "6.1.1",
+        "@semantic-release/error": "2.0.0",
+        "@semantic-release/last-release-npm": "2.0.2",
+        "@semantic-release/release-notes-generator": "4.0.5",
+        "execa": "0.8.0",
+        "fs-extra": "4.0.2",
         "git-head": "1.20.1",
-        "github": "8.2.1",
+        "github": "11.0.0",
         "lodash": "4.17.4",
         "nerf-dart": "1.0.0",
         "nopt": "4.0.1",
         "normalize-package-data": "2.4.0",
         "npmconf": "2.1.2",
         "npmlog": "4.1.2",
+        "p-series": "1.0.0",
         "parse-github-repo-url": "1.4.1",
         "require-relative": "0.8.7",
-        "run-auto": "2.0.0",
-        "run-series": "1.1.4",
         "semver": "5.4.1"
       },
       "dependencies": {
+        "@semantic-release/commit-analyzer": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-3.0.7.tgz",
+          "integrity": "sha512-bxCvvDsZeQp6Fvev8CdAV4pu9rEt8NOuLIFS0E8RLjKRnqQVL/fGAwpQWnRQ5hc08UZroguBNEENWpKBubWmKQ==",
+          "dev": true,
+          "requires": {
+            "@semantic-release/error": "2.0.0",
+            "conventional-changelog-angular": "1.5.0",
+            "conventional-commits-parser": "2.0.0",
+            "import-from": "2.1.0",
+            "lodash": "4.17.4",
+            "pify": "3.0.0"
+          }
+        },
+        "@semantic-release/condition-travis": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@semantic-release/condition-travis/-/condition-travis-6.1.1.tgz",
+          "integrity": "sha512-t52gG3VAIgNnWEFMfayRafZjfgERq0uxMsgMGSCSxBrX2DwJozo6Oel8N58GMURMH9APaU6caoC6nlZNgKy3kA==",
+          "dev": true,
+          "requires": {
+            "@semantic-release/error": "2.0.0",
+            "github": "12.0.1",
+            "parse-github-repo-url": "1.4.1",
+            "semver": "5.4.1",
+            "travis-deploy-once": "3.0.0"
+          },
+          "dependencies": {
+            "github": {
+              "version": "12.0.1",
+              "resolved": "https://registry.npmjs.org/github/-/github-12.0.1.tgz",
+              "integrity": "sha512-ErpdkNtZfh8GPdNtoaTUD7tlyAL82Is/W4BZcwYi5zwtIP0kKhbH1OzTZgvHjqXO1EUVfKH0f6VhaQJO5qeT1w==",
+              "dev": true,
+              "requires": {
+                "follow-redirects": "1.2.5",
+                "https-proxy-agent": "2.1.0",
+                "mime": "2.0.3",
+                "netrc": "0.1.4"
+              }
+            }
+          }
+        },
+        "@semantic-release/error": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.0.0.tgz",
+          "integrity": "sha512-756QdQyJGh4126IAt4CCJlmf+5qjkfzUv//RxsJHtJh0M+oy6WstA2IA5iqQeoXpc1GfgertkkMF39HJ/9VPpA==",
+          "dev": true
+        },
+        "@semantic-release/last-release-npm": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@semantic-release/last-release-npm/-/last-release-npm-2.0.2.tgz",
+          "integrity": "sha512-ge5AWWtcrEd6GeG4tsv8gx774G9aPNrrornjBBqNDqN7Eg/xI914ftcnmSgnsbmKcqmq4g+QElIJhNMvsfpOkQ==",
+          "dev": true,
+          "requires": {
+            "@semantic-release/error": "2.0.0",
+            "npm-registry-client": "8.5.0",
+            "npmlog": "4.1.2"
+          }
+        },
+        "@semantic-release/release-notes-generator": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-4.0.5.tgz",
+          "integrity": "sha512-LznqPnifl8jtQkV5ZXnQbqMLx9QROoX5d/FLteLyKy3AznLSubm5rH0LndKvf9ZI8XU8jwgLYu+wbLAEIR2PPg==",
+          "dev": true,
+          "requires": {
+            "@semantic-release/error": "2.0.0",
+            "conventional-changelog-angular": "1.5.0",
+            "conventional-changelog-core": "1.9.1",
+            "get-stream": "3.0.0",
+            "import-from": "2.1.0",
+            "lodash": "4.17.4",
+            "pify": "3.0.0"
+          }
+        },
+        "agent-base": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+          "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "5.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+          "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9"
+          }
+        },
         "github": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/github/-/github-8.2.1.tgz",
-          "integrity": "sha1-YWsiEfvNHMhjFmmu1nZT5i61OBY=",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/github/-/github-11.0.0.tgz",
+          "integrity": "sha1-7bMt9e+zPK0ATr8L3SpLMLtjqFQ=",
           "dev": true,
           "requires": {
             "follow-redirects": "0.0.7",
             "https-proxy-agent": "1.0.0",
-            "mime": "1.4.0",
+            "mime": "1.4.1",
             "netrc": "0.1.4"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+              "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+              "dev": true,
+              "requires": {
+                "extend": "3.0.1",
+                "semver": "5.0.3"
+              }
+            },
+            "follow-redirects": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+              "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+              "dev": true,
+              "requires": {
+                "debug": "2.6.9",
+                "stream-consume": "0.1.0"
+              }
+            },
+            "https-proxy-agent": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+              "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+              "dev": true,
+              "requires": {
+                "agent-base": "2.1.1",
+                "debug": "2.6.9",
+                "extend": "3.0.1"
+              }
+            },
+            "mime": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+              "dev": true
+            },
+            "semver": {
+              "version": "5.0.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "https-proxy-agent": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
+          "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
+          "dev": true,
+          "requires": {
+            "agent-base": "4.1.1",
+            "debug": "2.6.9"
+          }
+        },
+        "mime": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
+          "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==",
+          "dev": true
+        },
+        "npm-registry-client": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.0.tgz",
+          "integrity": "sha512-Nkcw24bfECKFNt0FLDQ+PjVqSlKxMggcboXiUBIvjbCnA15xjRO4kCwRDluGNXZjHFLx/vPjN4+ESXyVjpXLbQ==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "4.2.1",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.83.0",
+            "retry": "0.10.1",
+            "semver": "5.4.1",
+            "slide": "1.1.6",
+            "ssri": "4.1.6"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "travis-deploy-once": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/travis-deploy-once/-/travis-deploy-once-3.0.0.tgz",
+          "integrity": "sha512-ST4Rs/WrAeq6MXi9/Iagw7p1MLje1mPV1UqGXB2jvBAweBlFHOjqbBvfpGLjmI+ZckOc2FkX0X1gNBOa9nc13w==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "p-retry": "1.0.0",
+            "semver": "5.4.1",
+            "travis-ci": "2.1.1"
           }
         }
       }
@@ -4754,6 +4774,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shelljs": {
@@ -4839,15 +4874,6 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
@@ -4877,6 +4903,15 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
+      }
+    },
+    "ssri": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "standard": {
@@ -4913,21 +4948,6 @@
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
       "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
       "dev": true
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1"
-      }
     },
     "stream-consume": {
       "version": "0.1.0",
@@ -4998,6 +5018,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-indent": {
@@ -5331,19 +5357,6 @@
         }
       }
     },
-    "travis-deploy-once": {
-      "version": "1.0.0-node-0.10-support",
-      "resolved": "https://registry.npmjs.org/travis-deploy-once/-/travis-deploy-once-1.0.0-node-0.10-support.tgz",
-      "integrity": "sha1-mOzOfZWy9Lpdze7r9Uud+HcT1eY=",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "6.26.0",
-        "bluebird": "3.5.0",
-        "request": "2.83.0",
-        "request-promise": "4.2.2",
-        "travis-ci": "2.1.1"
-      }
-    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -5560,6 +5573,12 @@
       "integrity": "sha1-7CaOcxudJ3p5pbWqBkOZDkBdYAs=",
       "dev": true
     },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
+    },
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
@@ -5653,6 +5672,15 @@
         "matcher-collection": "1.0.4"
       }
     },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
@@ -5706,6 +5734,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "make-dir": "^1.0.0",
     "mocha": "^3.3.0",
     "require-yaml": "^0.0.1",
-    "semantic-release": "^7.0.2",
+    "semantic-release": "^8.2.0",
     "standard": "^10.0.2",
     "walk-sync": "^0.3.2"
   },


### PR DESCRIPTION
Trying a major bump of `semantic-release` to see if we can recover from the issues outlined in https://github.com/semantic-release/semantic-release/issues/482