### PR TITLE
update source content to 1.7.9

### DIFF
--- a/content/en-US/docs/api/browser-view.md
+++ b/content/en-US/docs/api/browser-view.md
@@ -38,6 +38,14 @@ view.webContents.loadURL('https://electron.atom.io')
 * `options` Object (optional)
   * `webPreferences` Object (optional) - See [BrowserWindow](browser-window.md).
 
+### Static Methods
+
+#### `BrowserView.fromId(id)`
+
+* `id` Integer
+
+Returns `BrowserView` - The view with the given `id`.
+
 ### Instance Properties
 
 Objects created with `new BrowserView` have the following properties:

--- a/content/en-US/docs/api/browser-window-proxy.md
+++ b/content/en-US/docs/api/browser-window-proxy.md
@@ -50,4 +50,4 @@ The `BrowserWindowProxy` object has the following instance properties:
 
 #### `win.closed`
 
-A Boolean that is set to true after the child window gets closed.
+A `Boolean` that is set to true after the child window gets closed.

--- a/content/en-US/docs/api/browser-window.md
+++ b/content/en-US/docs/api/browser-window.md
@@ -582,6 +582,34 @@ Returns `BrowserWindow` - The window that owns the given `webContents`.
 
 Returns `BrowserWindow` - The window with the given `id`.
 
+#### `BrowserWindow.addExtension(path)`
+
+* `path` String
+
+Adds Chrome extension located at `path`, and returns extension's name.
+
+The method will also not return if the extension's manifest is missing or incomplete.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `BrowserWindow.removeExtension(name)`
+
+* `name` String
+
+Remove a Chrome extension by name.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `BrowserWindow.getExtensions()`
+
+Returns `Object` - The keys are the extension names and each value is
+an Object containing `name` and `version` properties.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
 #### `BrowserWindow.addDevToolsExtension(path)`
 
 * `path` String
@@ -1115,7 +1143,7 @@ Same as `webContents.reload`.
 
 #### `win.setMenu(menu)` _Linux_ _Windows_
 
-* `menu` Menu
+* `menu` Menu | null
 
 Sets the `menu` as the window's menu bar, setting it to `null` will remove the
 menu bar.

--- a/content/en-US/docs/api/client-request.md
+++ b/content/en-US/docs/api/client-request.md
@@ -143,7 +143,7 @@ Emitted when there is redirection and the mode is `manual`. Calling
 
 #### `request.chunkedEncoding`
 
-A Boolean specifying whether the request will use HTTP chunked transfer encoding
+A `Boolean` specifying whether the request will use HTTP chunked transfer encoding
 or not. Defaults to false. The property is readable and writable, however it can
 be set only before the first write operation as the HTTP headers are not yet put
 on the wire. Trying to set the `chunkedEncoding` property after the first write
@@ -184,7 +184,7 @@ before first write. Trying to call it after the first write will throw an error.
 string, it is converted into a Buffer using the specified encoding.
 * `encoding` String (optional) - Used to convert string chunks into Buffer
 objects. Defaults to 'utf-8'.
-* `callback` Function (optional) - Called after the write operation ends.  
+* `callback` Function (optional) - Called after the write operation ends.
 
 `callback` is essentially a dummy function introduced in the purpose of keeping
 similarity with the Node.js API. It is called asynchronously in the next tick

--- a/content/en-US/docs/api/dialog.md
+++ b/content/en-US/docs/api/dialog.md
@@ -46,6 +46,8 @@ The `dialog` module has the following methods:
     * `noResolveAliases` - Disable the automatic alias (symlink) path
       resolution.  Selected aliases will now return the alias path instead of
       their target path. _macOS_
+    * `treatPackageAsDirectory` - Treat packages, such as `.app` folders,
+      as a directory instead of a file. _macOS_
   * `message` String (optional) _macOS_ - Message to display above input
     boxes.
 * `callback` Function (optional)

--- a/content/en-US/docs/api/file-object.md
+++ b/content/en-US/docs/api/file-object.md
@@ -15,19 +15,17 @@ Example of getting a real path from a dragged-onto-the-app file:
 </div>
 
 <script>
-  const holder = document.getElementById('holder')
-  holder.ondragover = () => {
-    return false;
-  }
-  holder.ondragleave = holder.ondragend = () => {
-    return false;
-  }
-  holder.ondrop = (e) => {
-    e.preventDefault()
+  document.addEventListener('drop', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    
     for (let f of e.dataTransfer.files) {
       console.log('File(s) you dragged here: ', f.path)
     }
-    return false;
-  }
+  });
+  document.addEventListener('dragover', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+  });
 </script>
 ```

--- a/content/en-US/docs/api/incoming-message.md
+++ b/content/en-US/docs/api/incoming-message.md
@@ -43,15 +43,15 @@ An `IncomingMessage` instance has the following readable properties:
 
 #### `response.statusCode`
 
-An Integer indicating the HTTP response status code.
+An `Integer` indicating the HTTP response status code.
 
 #### `response.statusMessage`
 
-A String representing the HTTP status message.
+A `String` representing the HTTP status message.
 
 #### `response.headers`
 
-An Object representing the response HTTP headers. The `headers` object is
+An `Object` representing the response HTTP headers. The `headers` object is
 formatted as follows:
 
 * All header names are lowercased.
@@ -60,15 +60,15 @@ formatted as follows:
 
 #### `response.httpVersion`
 
-A String indicating the HTTP protocol version number. Typical values are '1.0'
+A `String` indicating the HTTP protocol version number. Typical values are '1.0'
 or '1.1'. Additionally `httpVersionMajor` and `httpVersionMinor` are two
 Integer-valued readable properties that return respectively the HTTP major and
 minor version numbers.
 
 #### `response.httpVersionMajor`
 
-An Integer indicating the HTTP protocol major version number.
+An `Integer` indicating the HTTP protocol major version number.
 
 #### `response.httpVersionMinor`
 
-An Integer indicating the HTTP protocol minor version number.
+An `Integer` indicating the HTTP protocol minor version number.

--- a/content/en-US/docs/api/menu-item.md
+++ b/content/en-US/docs/api/menu-item.md
@@ -93,17 +93,17 @@ The following properties are available on instances of `MenuItem`:
 
 #### `menuItem.enabled`
 
-A Boolean indicating whether the item is enabled, this property can be
+A `Boolean` indicating whether the item is enabled, this property can be
 dynamically changed.
 
 #### `menuItem.visible`
 
-A Boolean indicating whether the item is visible, this property can be
+A `Boolean` indicating whether the item is visible, this property can be
 dynamically changed.
 
 #### `menuItem.checked`
 
-A Boolean indicating whether the item is checked, this property can be
+A `Boolean` indicating whether the item is checked, this property can be
 dynamically changed.
 
 A `checkbox` menu item will toggle the `checked` property on and off when
@@ -116,8 +116,8 @@ You can add a `click` function for additional behavior.
 
 #### `menuItem.label`
 
-A String representing the menu items visible label
+A `String` representing the menu items visible label
 
 #### `menuItem.click`
 
-A Function that is fired when the MenuItem receives a click event
+A `Function` that is fired when the MenuItem receives a click event

--- a/content/en-US/docs/api/menu.md
+++ b/content/en-US/docs/api/menu.md
@@ -1,5 +1,6 @@
 ## Class: Menu
 
+
 > Create native application menus and context menus.
 
 Process: [Main](../glossary.md#main-process)
@@ -101,7 +102,7 @@ Inserts the `menuItem` to the `pos` position of the menu.
 
 #### `menu.items`
 
-A MenuItem[] array containing the menu's items.
+A `MenuItem[]` array containing the menu's items.
 
 Each `Menu` consists of multiple [`MenuItem`](menu-item.md)s and each `MenuItem`
 can have a submenu.

--- a/content/en-US/docs/api/notification.md
+++ b/content/en-US/docs/api/notification.md
@@ -31,13 +31,14 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
 
 * `options` Object
   * `title` String - A title for the notification, which will be shown at the top of the notification window when it is shown
-  * `subtitle` String - A subtitle for the notification, which will be displayed below the title. _macOS_
+  * `subtitle` String - (optional) A subtitle for the notification, which will be displayed below the title. _macOS_
   * `body` String - The body text of the notification, which will be displayed below the title or subtitle
   * `silent` Boolean - (optional) Whether or not to emit an OS notification noise when showing the notification
   * `icon` [NativeImage](native-image.md) - (optional) An icon to use in the notification
   * `hasReply` Boolean - (optional) Whether or not to add an inline reply option to the notification.  _macOS_
   * `replyPlaceholder` String - (optional) The placeholder to write in the inline reply input field. _macOS_
-  * `actions` [NotificationAction[]](structures/notification-action.md) - Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
+  * `sound` String - (optional) The name of the sound file to play when the notification is shown. _macOS_
+  * `actions` [NotificationAction[]](structures/notification-action.md) - (optional) Actions to add to the notification.  Please read the available actions and limitations in the `NotificationAction` documentation _macOS_
 
 
 ### Instance Events
@@ -102,3 +103,18 @@ Immediately shows the notification to the user, please note this means unlike th
 HTML5 Notification implementation, simply instantiating a `new Notification` does
 not immediately show it to the user, you need to call this method before the OS
 will display it.
+
+### Playing Sounds
+
+On macOS, you can specify the name of the sound you'd like to play when the
+notification is shown. Any of the default sounds (under System Preferences >
+Sound) can be used, in addition to custom sound files. Be sure that the sound
+file is copied under the app bundle (e.g., `YourApp.app/Contents/Resources`),
+or one of the following locations:
+
+* `~/Library/Sounds`
+* `/Library/Sounds`
+* `/Network/Library/Sounds`
+* `/System/Library/Sounds`
+
+See the [`NSSound`](https://developer.apple.com/documentation/appkit/nssound) docs for more information.

--- a/content/en-US/docs/api/touch-bar-scrubber.md
+++ b/content/en-US/docs/api/touch-bar-scrubber.md
@@ -22,12 +22,12 @@ Process: [Main](../tutorial/quick-start.md#main-process)
 
 The following properties are available on instances of `TouchBarScrubber`:
 
-#### `touchBarSegmentedControl.items`
+#### `touchBarScrubber.items`
 
 A `ScrubberItem[]` array representing the items in this scrubber. Updating this value immediately
 updates the control in the touch bar. Updating deep properties inside this array **does not update the touch bar**.
 
-#### `touchBarSegmentedControl.selectedStyle`
+#### `touchBarScrubber.selectedStyle`
 
 A `String` representing the style that selected items in the scrubber should have. Updating this value immediately
 updates the control in the touch bar.  Possible values:
@@ -36,7 +36,7 @@ updates the control in the touch bar.  Possible values:
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`
 * `null` - Actually null, not a string, removes all styles
 
-#### `touchBarSegmentedControl.overlayStyle`
+#### `touchBarScrubber.overlayStyle`
 
 A `String` representing the style that selected items in the scrubber should have. This style is overlayed on top
 of the scrubber item instead of being placed behind it. Updating this value immediately updates the control in the
@@ -46,12 +46,12 @@ touch bar.  Possible values:
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`
 * `null` - Actually null, not a string, removes all styles
 
-#### `touchBarSegmentedControl.showArrowButtons`
+#### `touchBarScrubber.showArrowButtons`
 
 A `Boolean` representing whether to show the left / right selection arrows in this scrubber. Updating this value
 immediately updates the control in the touch bar.  
 
-#### `touchBarSegmentedControl.mode`
+#### `touchBarScrubber.mode`
 
 A `String` representing the mode of this scrubber. Updating this value immediately
 updates the control in the touch bar. Possible values:
@@ -59,7 +59,7 @@ updates the control in the touch bar. Possible values:
 * `fixed` - Maps to `NSScrubberModeFixed`
 * `free` - Maps to `NSScrubberModeFree`
 
-#### `touchBarSegmentedControl.continuous`
+#### `touchBarScrubber.continuous`
 
 A `Boolean` representing whether this scrubber is continuous or not. Updating this value immediately
 updates the control in the touch bar.

--- a/content/en-US/docs/api/touch-bar.md
+++ b/content/en-US/docs/api/touch-bar.md
@@ -6,7 +6,7 @@ Process: [Main](../tutorial/quick-start.md#main-process)
 
 ### `new TouchBar(options)` _Experimental_
 
-* `options` - Object
+* `options` Object
   * `items` ([TouchBarButton](touch-bar-button.md) | [TouchBarColorPicker](touch-bar-color-picker.md) | [TouchBarGroup](touch-bar-group.md) | [TouchBarLabel](touch-bar-label.md) | [TouchBarPopover](touch-bar-popover.md) | [TouchBarScrubber](touch-bar-scrubber.md) | [TouchBarSegmentedControl](touch-bar-segmented-control.md) | [TouchBarSlider](touch-bar-slider.md) | [TouchBarSpacer](touch-bar-spacer.md))[]
   * `escapeItem` ([TouchBarButton](touch-bar-button.md) | [TouchBarColorPicker](touch-bar-color-picker.md) | [TouchBarGroup](touch-bar-group.md) | [TouchBarLabel](touch-bar-label.md) | [TouchBarPopover](touch-bar-popover.md) | [TouchBarScrubber](touch-bar-scrubber.md) | [TouchBarSegmentedControl](touch-bar-segmented-control.md) | [TouchBarSlider](touch-bar-slider.md) | [TouchBarSpacer](touch-bar-spacer.md)) (optional)
 
@@ -26,7 +26,7 @@ The following properties are available on instances of `TouchBar`:
 
 #### `touchBar.escapeItem`
 
-The `TouchBarItem` that will replace the "esc" button on the touch bar when set.
+The `TouchBarButton` that will replace the "esc" button on the touch bar when set.
 Setting to `null` restores the default "esc" button. Changing this value
 immediately updates the escape item in the touch bar.
 

--- a/content/en-US/docs/api/web-contents.md
+++ b/content/en-US/docs/api/web-contents.md
@@ -1335,11 +1335,11 @@ Returns `Integer` - The `pid` of the associated renderer process.
 
 #### `contents.id`
 
-A Integer representing the unique ID of this WebContents.
+A `Integer` representing the unique ID of this WebContents.
 
 #### `contents.session`
 
-A Session object ([session](session.md)) used by this webContents.
+A [`Session`](session.md) used by this webContents.
 
 #### `contents.hostWebContents`
 

--- a/content/en-US/docs/development/build-instructions-linux.md
+++ b/content/en-US/docs/development/build-instructions-linux.md
@@ -8,10 +8,10 @@ Follow the guidelines below for building Electron on Linux.
 * Python 2.7.x. Some distributions like CentOS 6.x still use Python 2.6.x
   so you may need to check your Python version with `python -V`.
 * Node.js. There are various ways to install Node. You can download
-  source code from [Node.js](http://nodejs.org) and compile from source.
+  source code from [nodejs.org](http://nodejs.org) and compile it.
   Doing so permits installing Node on your own home directory as a standard user.
   Or try repositories such as [NodeSource](https://nodesource.com/blog/nodejs-v012-iojs-and-the-nodesource-linux-repositories).
-* Clang 3.4 or later.
+* [clang](https://clang.llvm.org/get_started.html) 3.4 or later.
 * Development headers of GTK+ and libnotify.
 
 On Ubuntu, install the following libraries:
@@ -48,7 +48,7 @@ managers such as pacman. Or one can compile from source code.
 ## Getting the Code
 
 ```bash
-$ git clone https://github.com/electron/electron.git
+$ git clone https://github.com/electron/electron
 ```
 
 ## Bootstrapping
@@ -60,7 +60,7 @@ Downloading certain files can take a long time. Notice that we are using
 
 ```bash
 $ cd electron
-$ ./script/bootstrap.py -v
+$ ./script/bootstrap.py --verbose
 ```
 
 ### Cross compilation
@@ -73,7 +73,7 @@ $ sudo apt-get install libc6-dev-armhf-cross linux-libc-dev-armhf-cross \
                        g++-arm-linux-gnueabihf
 ```
 
-And to cross compile for `arm` or `ia32` targets, you should pass the
+And to cross-compile for `arm` or `ia32` targets, you should pass the
 `--target_arch` parameter to the `bootstrap.py` script:
 
 ```bash
@@ -98,7 +98,7 @@ $ ./script/create-dist.py
 ```
 
 This will put a working distribution with much smaller file sizes in
-the `dist` directory. After running the create-dist.py script, you
+the `dist` directory. After running the `create-dist.py` script, you
 may want to remove the 1.3+ gigabyte binary which is still in `out/R`.
 
 You can also build the `Debug` target only:
@@ -143,17 +143,29 @@ See [Build System Overview: Tests](build-system-overview.md#tests)
 ## Advanced topics
 
 The default building configuration is targeted for major desktop Linux
-distributions, to build for a specific distribution or device, following
+distributions. To build for a specific distribution or device, the following
 information may help you.
 
 ### Building `libchromiumcontent` locally
 
-To avoid using the prebuilt binaries of `libchromiumcontent`, you can pass the
-`--build_libchromiumcontent` switch to `bootstrap.py` script:
+To avoid using the prebuilt binaries of `libchromiumcontent`, you can build `libchromiumcontent` locally.  To do so, follow these steps:
+  1. Install [depot_tools](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install)
+  2. Install [additional build dependencies](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md#Install-additional-build-dependencies)
+  3. Fetch the git submodules:
+  
+  ```bash
+  $ git submodule update --init --recursive
+  ```
+  4. Copy the .gclient config file
 
-```bash
-$ ./script/bootstrap.py -v --build_libchromiumcontent
-```
+  ```bash
+  $ cp vendor/libchromiumcontent/.gclient .
+  ```
+  5. Pass the `--build_libchromiumcontent` switch to `bootstrap.py` script:
+
+  ```bash
+  $ ./script/bootstrap.py -v --build_libchromiumcontent
+  ```
 
 Note that by default the `shared_library` configuration is not built, so you can
 only build `Release` version of Electron if you use this mode:
@@ -164,10 +176,12 @@ $ ./script/build.py -c R
 
 ### Using system `clang` instead of downloaded `clang` binaries
 
-By default Electron is built with prebuilt `clang` binaries provided by Chromium
-project. If for some reason you want to build with the `clang` installed in your
-system, you can call `bootstrap.py` with `--clang_dir=<path>` switch. By passing
-it the build script will assume the `clang` binaries reside in `<path>/bin/`.
+By default Electron is built with prebuilt 
+[`clang`](https://clang.llvm.org/get_started.html) binaries provided by the
+Chromium project. If for some reason you want to build with the `clang` 
+installed in your system, you can call `bootstrap.py` with `--clang_dir=<path>` 
+switch. By passing it the build script will assume the `clang` binaries reside 
+in `<path>/bin/`.
 
 For example if you installed `clang` under `/user/local/bin/clang`:
 
@@ -176,7 +190,7 @@ $ ./script/bootstrap.py -v --build_libchromiumcontent --clang_dir /usr/local
 $ ./script/build.py -c R
 ```
 
-### Using other compilers other than `clang`
+### Using compilers other than `clang`
 
 To build Electron with compilers like `g++`, you first need to disable `clang`
 with `--disable_clang` switch first, and then set `CC` and `CXX` environment

--- a/content/en-US/docs/development/releasing.md
+++ b/content/en-US/docs/development/releasing.md
@@ -2,13 +2,11 @@
 
 This document describes the process for releasing a new version of Electron.
 
-## Compile release notes
-
-The current process is to maintain a local file, keeping track of notable changes as pull requests are merged. For examples of how to format the notes, see previous releases on [the releases page].
-
 ## Create a temporary branch
 
-Create a new branch from `master` named `release`.
+Create a new branch from `master`. Name it `release` or anything you like.
+
+Note: If you are creating a backport release, you'll check out `1-6-x`, `1-7-x`, etc instead of `master`. 
 
 ```sh
 git checkout master
@@ -17,6 +15,12 @@ git checkout -b release
 ```
 
 This branch is created as a precaution to prevent any merged PRs from sneaking into a release between the time the temporary release branch is created and the CI builds are complete.
+
+## Check for extant drafts
+
+The upload script [looks for an existing draft release](https://github.com/electron/electron/blob/7961a97d7ddbed657c6c867cc8426e02c236c077/script/upload.py#L173-L181). To prevent your new release
+from clobbering an existing draft, check [the releases page] and
+make sure there are no drafts.
 
 ## Bump the version
 
@@ -31,12 +35,94 @@ This will bump the version number in several files. See [this bump commit] for a
 
 Most releases will be `patch` level. Upgrades to Chrome or other major changes should use `minor`. For more info, see [electron-versioning].
 
+## Wait for builds :hourglass_flowing_sand:
+
+The presence of the word [`Bump`](https://github.com/electron/electron/blob/7961a97d7ddbed657c6c867cc8426e02c236c077/script/cibuild-linux#L3-L6) in the commit message created by the `bump-version` script
+will [trigger the release process](https://github.com/electron/electron/blob/7961a97d7ddbed657c6c867cc8426e02c236c077/script/cibuild#L82-L96).
+
+To monitor the build progress, see the following pages:
+
+- [208.52.191.140:8080/view/All/builds](http://208.52.191.140:8080/view/All/builds) for Mac and Windows
+- [jenkins.githubapp.com/label/chromium/](https://jenkins.githubapp.com/label/chromium/) for Linux
+
+## Compile release notes
+
+Writing release notes is a good way to keep yourself busy while the builds are running.
+For prior art, see existing releases on [the releases page].
+
+Tips:
+
+- Each listed item should reference a PR on electron/electron, not an issue, nor a PR from another repo like libcc.
+- No need to use link markup when referencing PRs. Strings like `#123` will automatically be converted to links on github.com.
+- To see the version of Chromium, V8, and Node in every version of Electron, visit [atom.io/download/electron/index.json](https://atom.io/download/electron/index.json).
+
+### Patch releases
+
+For a `patch` release, use the following format:
+
+```
+## Bug Fixes
+
+* Fixed a cross-platform thing. #123
+
+### Linux
+
+* Fixed a Linux thing. #123
+
+### macOS
+
+* Fixed a macOS thing. #123
+
+### Windows
+
+* Fixed a Windows thing. #1234
+
+## API Changes
+
+* Changed a thing. #123
+
+### Linux
+
+* Changed a Linux thing. #123
+
+### macOS
+
+* Changed a macOS thing. #123
+
+### Windows
+
+* Changed a Windows thing. #123
+```
+
+### Minor releases
+
+For a `minor` release (which is normally a Chromium update, and possibly also a Node update), e.g. `1.8.0`, use this format:
+
+```
+**Note:** This is a beta release. This is the first release running on upgraded versions of Chrome/Node.js/V8 and most likely will have have some instability and/or regressions.
+
+Please file new issues for any bugs you find in it.
+
+This release is published to [npm](https://www.npmjs.com/package/electron) under the `beta` tag and can be installed via `npm install electron@beta`.
+
+## Upgrades
+
+- Upgraded from Chrome `oldVersion` to `newVersion`. #123
+- Upgraded from Node `oldVersion` to `newVersion`. #123
+- Upgraded from v8 `oldVersion` to `newVersion`. #9116
+
+## Other Changes
+
+- Some other change. #123
+```
+
 ## Edit the release draft
 
 1. Visit [the releases page] and you'll see a new draft release with placeholder release notes.
 1. Edit the release and add release notes.
+1. Ensure the `prerelease` checkbox is checked. This should happen automatically for Electron versions >=1.7
 1. Click 'Save draft'. **Do not click 'Publish release'!**
-1. Wait for all the builds to pass. :hourglass_flowing_sand:
+1. Wait for all builds to pass before proceeding. 
 
 ## Merge temporary branch
 
@@ -99,3 +185,28 @@ git push origin :release # delete remote branch
 [the releases page]: https://github.com/electron/electron/releases
 [this bump commit]: https://github.com/electron/electron/commit/78ec1b8f89b3886b856377a1756a51617bc33f5a
 [electron-versioning]: /docs/tutorial/electron-versioning.md
+
+## Promoting a release on npm
+
+New releases are published to npm with the `beta` tag. Every release should 
+eventually get promoted to stable unless there's a good reason not to.
+
+Releases are normally given around two weeks in the wild before being promoted.
+Before promoting a release, check to see if there are any bug reports
+against that version, e.g. issues labeled with `version/1.7.x`.
+
+It's also good to ask users in Slack if they're using the beta versions successfully.
+
+To see what's beta and stable at any given time:
+
+```
+$ npm dist-tag ls electron  
+beta: 1.7.5
+latest: 1.6.11
+```
+
+To promote a beta version to stable (aka `latest`):
+
+```
+npm dist-tag add electron@1.2.3 latest
+```

--- a/content/en-US/docs/faq.md
+++ b/content/en-US/docs/faq.md
@@ -1,5 +1,20 @@
 # Electron FAQ
 
+## Why am I having trouble installing Electron?
+
+When running `npm install electron`, some users occasionally encounter 
+installation errors.
+
+In almost all cases, these errors are the result of network problems and not 
+actual issues with the `electron` npm package. Errors like `ELIFECYCLE`, 
+`EAI_AGAIN`, `ECONNRESET`, and `ETIMEDOUT` are all indications of such 
+network problems.  The best resolution is to try switching networks, or 
+just wait a bit and try installing again.
+
+You can also attempt to download Electron directly from 
+[electron/electron/releases](https://github.com/electron/electron/releases) 
+if installing via `npm` is failing.
+
 ## When will Electron upgrade to latest Chrome?
 
 The Chrome version of Electron is usually bumped within one or two weeks after

--- a/content/en-US/docs/glossary.md
+++ b/content/en-US/docs/glossary.md
@@ -12,11 +12,9 @@ The ASAR format was created primarily to improve performance on Windows... TODO
 
 ### Brightray
 
-Brightray is a static library that makes [libchromiumcontent]
-easier to use in applications.
-
-Brightray is a low-level dependency of Electron that does not concern the
-majority of Electron users.
+Brightray [was](https://github.com/electron-archive/brightray) a static library 
+that made [libchromiumcontent] easier to use in applications. It is now 
+deprecated and has been merged into Electron's codebase.
 
 ### CRT
 
@@ -44,8 +42,10 @@ serialized JSON messages between the [main] and [renderer] processes.
 
 ### libchromiumcontent
 
-A single, shared library that includes the Chromium Content module and all its
-dependencies (e.g., Blink, [V8], etc.).
+A shared library that includes the [Chromium Content module] and all its
+dependencies (e.g., Blink, [V8], etc.). Also referred to as "libcc".
+
+- [github.com/electron/libchromiumcontent](https://github.com/electron/libchromiumcontent)
 
 ### main process
 
@@ -142,8 +142,17 @@ available in "core".
 ### V8
 
 V8 is Google's open source JavaScript engine. It is written in C++ and is
-used in Google Chrome. V8 can run
-standalone, or can be embedded into any C++ application.
+used in Google Chrome. V8 can run standalone, or can be embedded into any C++ application.
+
+Electron builds V8 as part of Chromium and then points Node to that V8 when 
+building it.
+
+V8's version numbers always correspond to those of Google Chrome. Chrome 59 
+includes V8 5.9, Chrome 58 includes V8 5.8, etc.
+
+- [developers.google.com/v8](https://developers.google.com/v8)
+- [nodejs.org/api/v8.html](https://nodejs.org/api/v8.html)
+- [docs/development/v8-development.md](development/v8-development.md)
 
 ### webview
 
@@ -157,11 +166,12 @@ embedded content.
 [addons]: https://nodejs.org/api/addons.html
 [asar]: https://github.com/electron/asar
 [autoUpdater]: api/auto-updater.md
+[Chromium Content module]: https://www.chromium.org/developers/content-module
 [electron-builder]: https://github.com/electron-userland/electron-builder
 [libchromiumcontent]: #libchromiumcontent
 [Mac App Store Submission Guide]: tutorial/mac-app-store-submission-guide.md
 [main]: #main-process
 [renderer]: #renderer-process
-[Using Native Node Modules]: tutorial/using-native-node-modules.md
 [userland]: #userland
+[Using Native Node Modules]: tutorial/using-native-node-modules.md
 [V8]: #v8

--- a/content/en-US/docs/tutorial/installation.md
+++ b/content/en-US/docs/tutorial/installation.md
@@ -1,0 +1,78 @@
+# Installation
+
+> Tips for installing Electron
+
+To install prebuilt Electron binaries, use [`npm`](https://docs.npmjs.com/).
+The preferred method is to install Electron as a development dependency in your
+app:
+
+```sh
+npm install electron --save-dev --save-exact
+```
+
+The `--save-exact` flag is recommended as Electron does not follow semantic
+versioning. See the
+[versioning doc](https://electron.atom.io/docs/tutorial/electron-versioning/)
+for info on how to manage Electron versions in your apps.
+
+## Global Installation
+
+You can also install the `electron` command globally in your `$PATH`:
+
+```sh
+npm install electron -g
+```
+
+## Customization
+
+If you want to change the architecture that is downloaded (e.g., `ia32` on an
+`x64` machine), you can use the `--arch` flag with npm install or set the
+`npm_config_arch` environment variable:
+
+```shell
+npm install --arch=ia32 electron
+```
+
+In addition to changing the architecture, you can also specify the platform 
+(e.g., `win32`, `linux`, etc.) using the `--platform` flag:
+
+```shell
+npm install --platform=win32 electron
+```
+
+## Proxies
+
+If you need to use an HTTP proxy you can [set these environment variables](https://github.com/request/request/tree/f0c4ec061141051988d1216c24936ad2e7d5c45d#controlling-proxy-behaviour-using-environment-variables).
+
+## Troubleshooting
+
+When running `npm install electron`, some users occasionally encounter 
+installation errors.
+
+In almost all cases, these errors are the result of network problems and not 
+actual issues with the `electron` npm package. Errors like `ELIFECYCLE`, 
+`EAI_AGAIN`, `ECONNRESET`, and `ETIMEDOUT` are all indications of such 
+network problems. The best resolution is to try switching networks, or 
+just wait a bit and try installing again.
+
+You can also attempt to download Electron directly from 
+[electron/electron/releases](https://github.com/electron/electron/releases) 
+if installing via `npm` is failing.
+
+If installation fails with an `EACCESS` error you may need to 
+[fix your npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
+
+If the above error persists, the [unsafe-perm](https://docs.npmjs.com/misc/config#unsafe-perm) flag may need to be set to true:
+
+```sh
+sudo npm install electron --unsafe-perm=true
+```
+
+On slower networks, it may be advisable to use the `--verbose` flag in order to show download progress:
+
+```sh
+npm install --verbose electron
+```
+
+If you need to force a re-download of the asset and the SHASUM file set the
+`force_no_cache` enviroment variable to `true`.

--- a/content/en-US/docs/tutorial/windows-store-guide.md
+++ b/content/en-US/docs/tutorial/windows-store-guide.md
@@ -134,7 +134,7 @@ that mode, the CLI will install and run your application in blank Windows Contai
 to determine what modifications your application is exactly doing to the operating
 system.
 
-Before running the CLI for the, you will have to setup the "Windows Desktop App
+Before running the CLI for the first time, you will have to setup the "Windows Desktop App
 Converter". This will take a few minutes, but don't worry - you only have to do
 this once. Download and Desktop App Converter from [here][app-converter].
 You will receive two files: `DesktopAppConverter.zip` and `BaseImage-14316.wim`.

--- a/content/en-US/electron-api.json
+++ b/content/en-US/electron-api.json
@@ -6,11 +6,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "app",
     "websiteUrl": "http://electron.atom.io/docs/api/app",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/app.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/app.md",
     "methods": [
       {
         "name": "quit",
@@ -1619,11 +1619,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "auto-updater",
     "websiteUrl": "http://electron.atom.io/docs/api/auto-updater",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/auto-updater.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/auto-updater.md",
     "methods": [
       {
         "name": "setFeedURL",
@@ -1730,11 +1730,11 @@
   },
   {
     "name": "BluetoothDevice",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "bluetooth-device",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/bluetooth-device",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/bluetooth-device.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/bluetooth-device.md",
     "properties": [
       {
         "name": "deviceName",
@@ -1759,11 +1759,30 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "browser-view",
     "websiteUrl": "http://electron.atom.io/docs/api/browser-view",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/browser-view.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/browser-view.md",
+    "staticMethods": [
+      {
+        "name": "fromId",
+        "signature": "(id)",
+        "parameters": [
+          {
+            "name": "id",
+            "type": "Integer",
+            "collection": false,
+            "required": true
+          }
+        ],
+        "returns": {
+          "type": "BrowserView",
+          "collection": false,
+          "description": "The view with the given id."
+        }
+      }
+    ],
     "constructorMethod": {
       "signature": "([options])",
       "parameters": [
@@ -1873,11 +1892,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "browser-window",
     "websiteUrl": "http://electron.atom.io/docs/api/browser-window",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/browser-window.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/browser-window.md",
     "staticMethods": [
       {
         "name": "getAllWindows",
@@ -1929,6 +1948,42 @@
           "type": "BrowserWindow",
           "collection": false,
           "description": "The window with the given id."
+        }
+      },
+      {
+        "name": "addExtension",
+        "signature": "(path)",
+        "description": "Adds Chrome extension located at path, and returns extension's name. The method will also not return if the extension's manifest is missing or incomplete. Note: This API cannot be called before the ready event of the app module is emitted.",
+        "parameters": [
+          {
+            "name": "path",
+            "type": "String",
+            "collection": false,
+            "required": true
+          }
+        ]
+      },
+      {
+        "name": "removeExtension",
+        "signature": "(name)",
+        "description": "Remove a Chrome extension by name. Note: This API cannot be called before the ready event of the app module is emitted.",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "String",
+            "collection": false,
+            "required": true
+          }
+        ]
+      },
+      {
+        "name": "getExtensions",
+        "signature": "()",
+        "description": "Note: This API cannot be called before the ready event of the app module is emitted.",
+        "returns": {
+          "type": "Object",
+          "collection": false,
+          "description": "The keys are the extension names and each value is an Object containing name and version properties."
         }
       },
       {
@@ -3595,7 +3650,16 @@
         "parameters": [
           {
             "name": "menu",
-            "type": "Menu",
+            "type": [
+              {
+                "typeName": "Menu",
+                "collection": false
+              },
+              {
+                "typeName": "null",
+                "collection": false
+              }
+            ],
             "collection": false,
             "required": true
           }
@@ -4303,11 +4367,11 @@
       "main": false,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "browser-window-proxy",
     "websiteUrl": "http://electron.atom.io/docs/api/browser-window-proxy",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/browser-window-proxy.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/browser-window-proxy.md",
     "instanceName": "win",
     "instanceMethods": [
       {
@@ -4374,11 +4438,11 @@
   },
   {
     "name": "Certificate",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "certificate",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/certificate",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/certificate.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/certificate.md",
     "properties": [
       {
         "name": "data",
@@ -4454,11 +4518,11 @@
   },
   {
     "name": "CertificatePrincipal",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "certificate-principal",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/certificate-principal",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/certificate-principal.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/certificate-principal.md",
     "properties": [
       {
         "name": "commonName",
@@ -4511,11 +4575,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "client-request",
     "websiteUrl": "http://electron.atom.io/docs/api/client-request",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/client-request.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/client-request.md",
     "constructorMethod": {
       "signature": "(options)",
       "parameters": [
@@ -4839,11 +4903,11 @@
       "main": true,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "clipboard",
     "websiteUrl": "http://electron.atom.io/docs/api/clipboard",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/clipboard.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/clipboard.md",
     "methods": [
       {
         "name": "readText",
@@ -5264,11 +5328,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "content-tracing",
     "websiteUrl": "http://electron.atom.io/docs/api/content-tracing",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/content-tracing.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/content-tracing.md",
     "methods": [
       {
         "name": "getCategories",
@@ -5464,11 +5528,11 @@
   },
   {
     "name": "Cookie",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "cookie",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/cookie",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/cookie.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/cookie.md",
     "properties": [
       {
         "name": "name",
@@ -5542,11 +5606,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "cookies",
     "websiteUrl": "http://electron.atom.io/docs/api/cookies",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/cookies.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/cookies.md",
     "instanceName": "cookies",
     "instanceMethods": [
       {
@@ -5815,11 +5879,11 @@
   },
   {
     "name": "CPUUsage",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "cpu-usage",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/cpu-usage",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/cpu-usage.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/cpu-usage.md",
     "properties": [
       {
         "name": "percentCPUUsage",
@@ -5839,11 +5903,11 @@
   },
   {
     "name": "CrashReport",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "crash-report",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/crash-report",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/crash-report.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/crash-report.md",
     "properties": [
       {
         "name": "date",
@@ -5868,11 +5932,11 @@
       "main": true,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "crash-reporter",
     "websiteUrl": "http://electron.atom.io/docs/api/crash-reporter",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/crash-reporter.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/crash-reporter.md",
     "methods": [
       {
         "name": "start",
@@ -6015,11 +6079,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "debugger",
     "websiteUrl": "http://electron.atom.io/docs/api/debugger",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/debugger.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/debugger.md",
     "instanceName": "debugger",
     "instanceMethods": [
       {
@@ -6151,11 +6215,11 @@
       "main": false,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "desktop-capturer",
     "websiteUrl": "http://electron.atom.io/docs/api/desktop-capturer",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/desktop-capturer.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/desktop-capturer.md",
     "methods": [
       {
         "name": "getSources",
@@ -6212,11 +6276,11 @@
   },
   {
     "name": "DesktopCapturerSource",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "desktop-capturer-source",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/desktop-capturer-source",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/desktop-capturer-source.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/desktop-capturer-source.md",
     "properties": [
       {
         "name": "id",
@@ -6248,11 +6312,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "dialog",
     "websiteUrl": "http://electron.atom.io/docs/api/dialog",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/dialog.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/dialog.md",
     "methods": [
       {
         "name": "showOpenDialog",
@@ -6333,6 +6397,10 @@
                   {
                     "value": "noResolveAliases",
                     "description": "Disable the automatic alias (symlink) path resolution. Selected aliases will now return the alias path instead of their target path. <em>macOS</em>"
+                  },
+                  {
+                    "value": "treatPackageAsDirectory",
+                    "description": "Treat packages, such as <code>.app</code> folders, as a directory instead of a file. <em>macOS</em>"
                   }
                 ]
               },
@@ -6659,11 +6727,11 @@
   },
   {
     "name": "Display",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "display",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/display",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/display.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/display.md",
     "properties": [
       {
         "name": "id",
@@ -6741,11 +6809,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "download-item",
     "websiteUrl": "http://electron.atom.io/docs/api/download-item",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/download-item.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/download-item.md",
     "instanceName": "downloadItem",
     "instanceMethods": [
       {
@@ -6967,11 +7035,11 @@
   },
   {
     "name": "FileFilter",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "file-filter",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/file-filter",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/file-filter.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/file-filter.md",
     "properties": [
       {
         "name": "name",
@@ -6996,11 +7064,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "global-shortcut",
     "websiteUrl": "http://electron.atom.io/docs/api/global-shortcut",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/global-shortcut.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/global-shortcut.md",
     "methods": [
       {
         "name": "register",
@@ -7061,11 +7129,11 @@
   },
   {
     "name": "GPUFeatureStatus",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "gpu-feature-status",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/gpu-feature-status",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/gpu-feature-status.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/gpu-feature-status.md",
     "properties": [
       {
         "name": "2d_canvas",
@@ -7167,11 +7235,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "incoming-message",
     "websiteUrl": "http://electron.atom.io/docs/api/incoming-message",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/incoming-message.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/incoming-message.md",
     "instanceName": "response",
     "instanceProperties": [
       {
@@ -7241,11 +7309,11 @@
   },
   {
     "name": "IOCounters",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "io-counters",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/io-counters",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/io-counters.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/io-counters.md",
     "properties": [
       {
         "name": "readOperationCount",
@@ -7298,11 +7366,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "ipc-main",
     "websiteUrl": "http://electron.atom.io/docs/api/ipc-main",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/ipc-main.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/ipc-main.md",
     "methods": [
       {
         "name": "on",
@@ -7383,11 +7451,11 @@
       "main": false,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "ipc-renderer",
     "websiteUrl": "http://electron.atom.io/docs/api/ipc-renderer",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/ipc-renderer.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/ipc-renderer.md",
     "methods": [
       {
         "name": "on",
@@ -7525,11 +7593,11 @@
   },
   {
     "name": "JumpListCategory",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "jump-list-category",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/jump-list-category",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/jump-list-category.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/jump-list-category.md",
     "properties": [
       {
         "name": "type",
@@ -7574,11 +7642,11 @@
   },
   {
     "name": "JumpListItem",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "jump-list-item",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/jump-list-item",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/jump-list-item.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/jump-list-item.md",
     "properties": [
       {
         "name": "type",
@@ -7654,11 +7722,11 @@
   },
   {
     "name": "MemoryInfo",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "memory-info",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/memory-info",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/memory-info.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/memory-info.md",
     "properties": [
       {
         "name": "pid",
@@ -7699,11 +7767,11 @@
   },
   {
     "name": "MemoryUsageDetails",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "memory-usage-details",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/memory-usage-details",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/memory-usage-details.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/memory-usage-details.md",
     "properties": [
       {
         "name": "count",
@@ -7735,11 +7803,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "menu",
     "websiteUrl": "http://electron.atom.io/docs/api/menu",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/menu.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/menu.md",
     "staticMethods": [
       {
         "name": "setApplicationMenu",
@@ -7916,11 +7984,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "menu-item",
     "websiteUrl": "http://electron.atom.io/docs/api/menu-item",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/menu-item.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/menu-item.md",
     "constructorMethod": {
       "signature": "(options)",
       "parameters": [
@@ -8119,11 +8187,11 @@
   },
   {
     "name": "MimeTypedBuffer",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "mime-typed-buffer",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/mime-typed-buffer",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/mime-typed-buffer.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/mime-typed-buffer.md",
     "properties": [
       {
         "name": "mimeType",
@@ -8148,11 +8216,11 @@
       "main": true,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "native-image",
     "websiteUrl": "http://electron.atom.io/docs/api/native-image",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/native-image.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/native-image.md",
     "instanceName": "image",
     "instanceMethods": [
       {
@@ -8457,11 +8525,11 @@
       "main": true,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "native-image",
     "websiteUrl": "http://electron.atom.io/docs/api/native-image",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/native-image.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/native-image.md",
     "methods": [
       {
         "name": "createEmpty",
@@ -8561,11 +8629,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "net",
     "websiteUrl": "http://electron.atom.io/docs/api/net",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/net.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/net.md",
     "methods": [
       {
         "name": "request",
@@ -8603,11 +8671,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "notification",
     "websiteUrl": "http://electron.atom.io/docs/api/notification",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/notification.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/notification.md",
     "staticMethods": [
       {
         "name": "isSupported",
@@ -8640,7 +8708,7 @@
               "type": "String",
               "collection": false,
               "description": "A subtitle for the notification, which will be displayed below the title.",
-              "required": true
+              "required": false
             },
             {
               "name": "body",
@@ -8678,11 +8746,18 @@
               "required": false
             },
             {
+              "name": "sound",
+              "type": "String",
+              "collection": false,
+              "description": "The name of the sound file to play when the notification is shown.",
+              "required": false
+            },
+            {
               "name": "actions",
               "type": "NotificationAction",
               "collection": true,
               "description": "Actions to add to the notification. Please read the available actions and limitations in the NotificationAction documentation",
-              "required": true
+              "required": false
             }
           ]
         }
@@ -8780,11 +8855,11 @@
   },
   {
     "name": "NotificationAction",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "notification-action",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/notification-action",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/notification-action.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/notification-action.md",
     "properties": [
       {
         "name": "type",
@@ -8809,11 +8884,11 @@
   },
   {
     "name": "Point",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "point",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/point",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/point.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/point.md",
     "properties": [
       {
         "name": "x",
@@ -8838,11 +8913,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "power-monitor",
     "websiteUrl": "http://electron.atom.io/docs/api/power-monitor",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/power-monitor.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/power-monitor.md",
     "events": [
       {
         "name": "suspend",
@@ -8875,11 +8950,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "power-save-blocker",
     "websiteUrl": "http://electron.atom.io/docs/api/power-save-blocker",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/power-save-blocker.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/power-save-blocker.md",
     "methods": [
       {
         "name": "start",
@@ -8946,11 +9021,11 @@
   },
   {
     "name": "PrinterInfo",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "printer-info",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/printer-info",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/printer-info.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/printer-info.md",
     "properties": [
       {
         "name": "name",
@@ -8989,11 +9064,11 @@
       "main": true,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "process",
     "websiteUrl": "http://electron.atom.io/docs/api/process",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/process.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/process.md",
     "methods": [
       {
         "name": "crash",
@@ -9213,11 +9288,11 @@
   },
   {
     "name": "ProcessMetric",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "process-metric",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/process-metric",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/process-metric.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/process-metric.md",
     "properties": [
       {
         "name": "pid",
@@ -9256,11 +9331,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "protocol",
     "websiteUrl": "http://electron.atom.io/docs/api/protocol",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/protocol.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/protocol.md",
     "methods": [
       {
         "name": "registerStandardSchemes",
@@ -10207,11 +10282,11 @@
   },
   {
     "name": "Rectangle",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "rectangle",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/rectangle",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/rectangle.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/rectangle.md",
     "properties": [
       {
         "name": "x",
@@ -10250,11 +10325,11 @@
       "main": false,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "remote",
     "websiteUrl": "http://electron.atom.io/docs/api/remote",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/remote.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/remote.md",
     "methods": [
       {
         "name": "require",
@@ -10319,11 +10394,11 @@
   },
   {
     "name": "RemoveClientCertificate",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "remove-client-certificate",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/remove-client-certificate",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/remove-client-certificate.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/remove-client-certificate.md",
     "properties": [
       {
         "name": "type",
@@ -10343,11 +10418,11 @@
   },
   {
     "name": "RemovePassword",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "remove-password",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/remove-password",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/remove-password.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/remove-password.md",
     "properties": [
       {
         "name": "type",
@@ -10414,11 +10489,11 @@
       "main": true,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "screen",
     "websiteUrl": "http://electron.atom.io/docs/api/screen",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/screen.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/screen.md",
     "methods": [
       {
         "name": "getCursorScreenPoint",
@@ -10559,11 +10634,11 @@
   },
   {
     "name": "ScrubberItem",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "scrubber-item",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/scrubber-item",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/scrubber-item.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/scrubber-item.md",
     "properties": [
       {
         "name": "label",
@@ -10583,11 +10658,11 @@
   },
   {
     "name": "SegmentedControlSegment",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "segmented-control-segment",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/segmented-control-segment",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/segmented-control-segment.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/segmented-control-segment.md",
     "properties": [
       {
         "name": "label",
@@ -10619,11 +10694,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "session",
     "websiteUrl": "http://electron.atom.io/docs/api/session",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/session.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/session.md",
     "methods": [
       {
         "name": "fromPartition",
@@ -10675,11 +10750,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "session",
     "websiteUrl": "http://electron.atom.io/docs/api/session",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/session.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/session.md",
     "instanceName": "ses",
     "instanceMethods": [
       {
@@ -11249,11 +11324,11 @@
       "main": true,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "shell",
     "websiteUrl": "http://electron.atom.io/docs/api/shell",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/shell.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/shell.md",
     "methods": [
       {
         "name": "showItemInFolder",
@@ -11435,11 +11510,11 @@
   },
   {
     "name": "ShortcutDetails",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "shortcut-details",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/shortcut-details",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/shortcut-details.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/shortcut-details.md",
     "properties": [
       {
         "name": "target",
@@ -11494,11 +11569,11 @@
   },
   {
     "name": "Size",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "size",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/size",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/size.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/size.md",
     "properties": [
       {
         "name": "width",
@@ -11523,11 +11598,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "system-preferences",
     "websiteUrl": "http://electron.atom.io/docs/api/system-preferences",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/system-preferences.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/system-preferences.md",
     "methods": [
       {
         "name": "isDarkMode",
@@ -12032,11 +12107,11 @@
   },
   {
     "name": "Task",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "task",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/task",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/task.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/task.md",
     "properties": [
       {
         "name": "program",
@@ -12084,11 +12159,11 @@
   },
   {
     "name": "ThumbarButton",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "thumbar-button",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/thumbar-button",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/thumbar-button.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/thumbar-button.md",
     "properties": [
       {
         "name": "icon",
@@ -12128,11 +12203,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "touch-bar",
     "websiteUrl": "http://electron.atom.io/docs/api/touch-bar",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar.md",
     "staticProperties": [
       {
         "name": "TouchBarButton",
@@ -12141,11 +12216,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-button",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-button",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-button.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-button.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12235,11 +12310,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-color-picker",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-color-picker",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-color-picker.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-color-picker.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12306,11 +12381,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-group",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-group",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-group.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-group.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12340,11 +12415,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-label",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-label",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-label.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-label.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12395,11 +12470,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-popover",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-popover",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-popover.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-popover.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12464,11 +12539,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-scrubber",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-scrubber",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-scrubber.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-scrubber.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12556,7 +12631,7 @@
             }
           ]
         },
-        "instanceName": "touchBarSegmentedControl",
+        "instanceName": "touchBarScrubber",
         "instanceProperties": [
           {
             "name": "items",
@@ -12603,11 +12678,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-segmented-control",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-segmented-control",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-segmented-control.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-segmented-control.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12749,11 +12824,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-slider",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-slider",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-slider.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-slider.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12846,11 +12921,11 @@
           "main": true,
           "renderer": false
         },
-        "version": "1.7.5",
+        "version": "1.7.9",
         "type": "Class",
         "slug": "touch-bar-spacer",
         "websiteUrl": "http://electron.atom.io/docs/api/touch-bar-spacer",
-        "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/touch-bar-spacer.md",
+        "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/touch-bar-spacer.md",
         "constructorMethod": {
           "signature": "(options)",
           "parameters": [
@@ -12892,47 +12967,100 @@
       "signature": "(options)",
       "parameters": [
         {
-          "name": "items",
-          "type": [
+          "name": "options",
+          "type": "Object",
+          "collection": false,
+          "required": true,
+          "properties": [
             {
-              "typeName": "TouchBarButton",
-              "collection": false
+              "name": "items",
+              "type": [
+                {
+                  "typeName": "TouchBarButton",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarColorPicker",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarGroup",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarLabel",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarPopover",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarScrubber",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarSegmentedControl",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarSlider",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarSpacer",
+                  "collection": false
+                }
+              ],
+              "collection": true,
+              "description": "",
+              "required": true
             },
             {
-              "typeName": "TouchBarColorPicker",
-              "collection": false
-            },
-            {
-              "typeName": "TouchBarGroup",
-              "collection": false
-            },
-            {
-              "typeName": "TouchBarLabel",
-              "collection": false
-            },
-            {
-              "typeName": "TouchBarPopover",
-              "collection": false
-            },
-            {
-              "typeName": "TouchBarScrubber",
-              "collection": false
-            },
-            {
-              "typeName": "TouchBarSegmentedControl",
-              "collection": false
-            },
-            {
-              "typeName": "TouchBarSlider",
-              "collection": false
-            },
-            {
-              "typeName": "TouchBarSpacer",
-              "collection": false
+              "name": "escapeItem",
+              "type": [
+                {
+                  "typeName": "TouchBarButton",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarColorPicker",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarGroup",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarLabel",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarPopover",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarScrubber",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarSegmentedControl",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarSlider",
+                  "collection": false
+                },
+                {
+                  "typeName": "TouchBarSpacer",
+                  "collection": false
+                }
+              ],
+              "collection": false,
+              "description": "",
+              "required": false
             }
-          ],
-          "collection": true,
-          "required": true
+          ]
         }
       ]
     },
@@ -12940,7 +13068,7 @@
     "instanceProperties": [
       {
         "name": "escapeItem",
-        "description": "The TouchBarItem that will replace the \"esc\" button on the touch bar when set. Setting to null restores the default \"esc\" button. Changing this value immediately updates the escape item in the touch bar."
+        "description": "The TouchBarButton that will replace the \"esc\" button on the touch bar when set. Setting to null restores the default \"esc\" button. Changing this value immediately updates the escape item in the touch bar."
       }
     ]
   },
@@ -12951,11 +13079,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "tray",
     "websiteUrl": "http://electron.atom.io/docs/api/tray",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/tray.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/tray.md",
     "constructorMethod": {
       "signature": "(image)",
       "parameters": [
@@ -13396,11 +13524,11 @@
   },
   {
     "name": "UploadBlob",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "upload-blob",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/upload-blob",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/upload-blob.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/upload-blob.md",
     "properties": [
       {
         "name": "type",
@@ -13420,11 +13548,11 @@
   },
   {
     "name": "UploadData",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "upload-data",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/upload-data",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/upload-data.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/upload-data.md",
     "properties": [
       {
         "name": "bytes",
@@ -13451,11 +13579,11 @@
   },
   {
     "name": "UploadFile",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "upload-file",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/upload-file",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/upload-file.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/upload-file.md",
     "properties": [
       {
         "name": "type",
@@ -13496,11 +13624,11 @@
   },
   {
     "name": "UploadFileSystem",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "upload-file-system",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/upload-file-system",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/upload-file-system.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/upload-file-system.md",
     "properties": [
       {
         "name": "type",
@@ -13541,11 +13669,11 @@
   },
   {
     "name": "UploadRawData",
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Structure",
     "slug": "upload-raw-data",
     "websiteUrl": "http://electron.atom.io/docs/api/structures/upload-raw-data",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/structures/upload-raw-data.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/structures/upload-raw-data.md",
     "properties": [
       {
         "name": "type",
@@ -13570,11 +13698,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "web-contents",
     "websiteUrl": "http://electron.atom.io/docs/api/web-contents",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/web-contents.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/web-contents.md",
     "methods": [
       {
         "name": "getAllWebContents",
@@ -13620,11 +13748,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "web-contents",
     "websiteUrl": "http://electron.atom.io/docs/api/web-contents",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/web-contents.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/web-contents.md",
     "instanceName": "contents",
     "instanceMethods": [
       {
@@ -15068,7 +15196,7 @@
       },
       {
         "name": "session",
-        "description": "A Session object (session) used by this webContents.",
+        "description": "A Session used by this webContents.",
         "type": "Session",
         "collection": false
       },
@@ -16289,11 +16417,11 @@
       "main": false,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Module",
     "slug": "web-frame",
     "websiteUrl": "http://electron.atom.io/docs/api/web-frame",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/web-frame.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/web-frame.md",
     "methods": [
       {
         "name": "setZoomFactor",
@@ -16637,11 +16765,11 @@
       "main": true,
       "renderer": false
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Class",
     "slug": "web-request",
     "websiteUrl": "http://electron.atom.io/docs/api/web-request",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/web-request.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/web-request.md",
     "instanceName": "webRequest",
     "instanceMethods": [
       {
@@ -17308,11 +17436,11 @@
       "main": false,
       "renderer": true
     },
-    "version": "1.7.5",
+    "version": "1.7.9",
     "type": "Element",
     "slug": "webview-tag",
     "websiteUrl": "http://electron.atom.io/docs/api/webview-tag",
-    "repoUrl": "https://github.com/electron/electron/blob/v1.7.5/docs/api/webview-tag.md",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.7.9/docs/api/webview-tag.md",
     "methods": [
       {
         "name": "loadURL",

--- a/content/en-US/website/locale.yml
+++ b/content/en-US/website/locale.yml
@@ -65,27 +65,35 @@ view_all_releases_on_github: <a href="https://github.com/electron/electron-api-d
 quick_start:
   title:
     "Spin up the
-    <a href='https://github.com/electron/electron-quick-start' target='_blank' rel='noopener'>Quick Start</a>
+    <a href='https://github.com/electron/electron-quick-start' target='_blank'>Quick Start</a>
     app to see Electron in action:"
   description: A minimal Electron app with helpful notations.
   clone: Clone the Quick Start repository
   go_into_repo: Go into the repository
   install_deps: Install the dependencies and run
-  dive_deeper: Or dive deeper and read the <a href='https://electron.atom.io/docs/'>documentation</a>.
+  dive_deeper: Or dive deeper and read the <a href='/docs'>documentation</a>.
 
 need_help:
   title: Need Help?
-  description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum or our <a href='http://atom-slack.herokuapp.com/'>Slack</a> channel. Follow <a href="https://twitter.com/ElectronJS">@ElectronJS</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:electron@github.com">electron@github.com</a>.
+  description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum or our <a href='http://atom-slack.herokuapp.com/'>Slack</a> channel. Follow <a href="https://twitter.com/{{ site.twitter_username }}">@{{ site.twitter_username }}</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:electron@github.com">electron@github.com</a>.
 
 apps:
   title: Apps built on Electron
   description:
     With Electron, creating a desktop application for your company or idea is
     easy. Initially developed for GitHub's
-    <a href='https://atom.io' target='_blank' rel='noopener'>Atom editor</a>, Electron has
+    <a href='https://atom.io' target='_blank'>Atom editor</a>, Electron has
     since been used to create applications by companies like Microsoft,
     Facebook, Slack, and Docker.
   view_more: View more apps
   submit_your_own: submit your own
 
 or: or
+
+pages:
+  '/apps':
+    title: Electron Apps
+    description: Apps Built on Electron
+  '/contact':
+    title: Contact
+    description: Get in touch with the Electron team on Twitter, Slack, GitHub, or via email.


### PR DESCRIPTION
This bumps the source content from Electron 1.7.5 to 1.7.9.

For reference, the last PR that updated source content was #71 

This update was run using the refactored collector in #129 