### PR TITLE
Fix incorrect URL (welcome bot comment)

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -8,7 +8,7 @@ newPRWelcomeComment: >
 
   Note that translations should be made on [Crowdin](https://crowdin.com/project/electron) and _should not_ be submitted manually here as a pull request.
 
-  Please check out our [contributing guidelines](contributing.md).
+  Please check out our [contributing guidelines](https://github.com/electron/electron-i18n/blob/master/contributing.md).
 
   🙏
 


### PR DESCRIPTION
If just:
```
[contributing guidelines](contributing.md)
```
Will be rendered this URL: https://github.com/electron/electron-i18n/pull/contributing.md
I do not know if this happened before or not. So I edited it to the right URL.

Can check at that comment of the `bot`: https://github.com/electron/electron-i18n/pull/136#issuecomment-342536457