### PR TITLE
electron.atom.io → electronjs.org

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -57,8 +57,8 @@ Electron's documentation and website are authored in English.
 The source content in this repo is collected from a few places:
 
 - Markdown files from the [electron](https://github.com/electron/electron/tree/master/docs) repo.
-- YAML files from the [electron.atom.io](https://github.com/electron/electron.atom.io/tree/gh-pages/_data/) repo
-- Electron's [structured API docs](https://electron.atom.io/blog/2016/09/27/api-docs-json-schema).
+- YAML files from the [electronjs.org](https://github.com/electron/electronjs.org/blob/master/data/locale.yml) repo
+- Electron's [structured API docs](https://electronjs.org/blog/api-docs-json-schema).
 
 Here's the directory structure:
 

--- a/script/collect.js
+++ b/script/collect.js
@@ -77,9 +77,9 @@ async function fetchApiData () {
 }
 
 async function fetchWebsiteContent () {
-  console.log(`Fetching locale.yml from electron/electron.atom.io#neo`)
+  console.log(`Fetching locale.yml from electron/electronjs.org#master`)
 
-  const url = 'https://cdn.rawgit.com/electron/electron.atom.io/neo/data/locale.yml'
+  const url = 'https://rawgit.com/electron/electronjs.org/master/data/locale.yml'
   const response = await got(url)
   const content = response.body
   const websiteFile = path.join(englishBasepath, 'website', `locale.yml`)


### PR DESCRIPTION
Also fixes #128