### PR TITLE
enable tests to run without env secrets

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "mocha && standard --fix",
     "prepack": "check-for-leaks",
     "prepush": "check-for-leaks",
-    "pretest": "npm run stats && npm run build",
+    "pretest": "npm run build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   }
 }


### PR DESCRIPTION
This PR takes `npm run stats` out of the `pretest` script, so `npm test` will run without requiring a `.env` file or any secrets in the env.

Fixes #165 