### PR TITLE
do not load env in stats script

### DIFF
--- a/script/stats.js
+++ b/script/stats.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-require('dotenv-safe').load()
-
 const got = require('got')
 const fs = require('fs')
 const path = require('path')


### PR DESCRIPTION
https://travis-ci.org/electron/electron-i18n/builds/310025376 is failing because dot-env is called needlessly by the stats script. This should fix that.