### PR TITLE
customize crowdin commit message

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
+commit_message: 'feat: new translations'
 files:
   - source: /content/en-US/docs/*.md
     translation: /content/%locale%/docs/%original_file_name%


### PR DESCRIPTION
This is an attempt to change the wording of commit messages that come from Crowdin via @glotbot, so `semantic-release` will know to automatically create new releases when Crowdin PRs are merged. This `commit_message` property appears to be [undocumented](https://support.crowdin.com/configuration-file/) so I'm not sure what to expect..

Fixes #188 