### PR TITLE
retain only html within the <body> tag for each doc

### DIFF
--- a/script/build-module.js
+++ b/script/build-module.js
@@ -104,7 +104,7 @@ async function parseFile (file) {
     $(el).attr('src', URL.format(parsed))
   })
 
-  file.html = $.html()
+  file.html = $('body').html()
 
   // remove leftover file props from walk-sync
   delete file.mode

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,16 @@ describe('i18n.docs', () => {
     docs['/docs/tutorial/electron-versioning'].githubUrl.should.equal(`${base}/docs/tutorial/electron-versioning.md`)
   })
 
+  it('does not contain <html>, <head>, or <body> tag in compiled html', () => {
+    const docs = i18n.docs['en-US']
+    docs['/docs/api/accelerator'].html.should.not.contain('<html>')
+    docs['/docs/api/accelerator'].html.should.not.contain('</html>')
+    docs['/docs/api/accelerator'].html.should.not.contain('<head>')
+    docs['/docs/api/accelerator'].html.should.not.contain('</head>')
+    docs['/docs/api/accelerator'].html.should.not.contain('<body>')
+    docs['/docs/api/accelerator'].html.should.not.contain('</body>')
+  })
+
   // disabled until we come up with a nice strategy for
   // dealing with renamed files in electron/electron and how to redirect
   //

--- a/test/index.js
+++ b/test/index.js
@@ -28,13 +28,15 @@ describe('i18n.docs', () => {
   })
 
   it('does not contain <html>, <head>, or <body> tag in compiled html', () => {
-    const docs = i18n.docs['en-US']
-    docs['/docs/api/accelerator'].html.should.not.contain('<html>')
-    docs['/docs/api/accelerator'].html.should.not.contain('</html>')
-    docs['/docs/api/accelerator'].html.should.not.contain('<head>')
-    docs['/docs/api/accelerator'].html.should.not.contain('</head>')
-    docs['/docs/api/accelerator'].html.should.not.contain('<body>')
-    docs['/docs/api/accelerator'].html.should.not.contain('</body>')
+    const {html} = i18n.docs['en-US']['/docs/api/accelerator']
+    html.should.be.a('string')
+    html.should.contain('<p>')
+    html.should.not.contain('<html>')
+    html.should.not.contain('</html>')
+    html.should.not.contain('<head>')
+    html.should.not.contain('</head>')
+    html.should.not.contain('<body>')
+    html.should.not.contain('</body>')
   })
 
   // disabled until we come up with a nice strategy for


### PR DESCRIPTION
Fixes https://github.com/electron/electronjs.org/issues/964 where the inner html of each doc is a complete html document itself (i.e. contains opening and closing tags like `<html>`, `<body>`, etc).
Related: https://github.com/cheeriojs/cheerio/issues/1031#issuecomment-306329834